### PR TITLE
fix: prefer ephemeral landing-page launch with workspace fallback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -319,20 +319,19 @@ function App(): JSX.Element {
                     const isWorkspaceRequiredFallbackError = (err: Error): boolean => {
                         const status = (err as any)?.status;
                         const serverReason = (err as any)?.serverError?.reason;
-                        const reason =
-                            typeof serverReason === 'string'
-                                ? serverReason
-                                : typeof err.message === 'string'
-                                  ? err.message
-                                  : '';
+                        const request = (err as any)?.request;
 
-                        if (status !== 400) {
+                        if (status !== 400 || request?.kind !== LaunchRequest.KIND || request?.ephemeral !== true) {
                             return false;
                         }
 
-                        // Some service deployments currently return an empty 400 body for this rejection,
-                        // so the backend reason is not always available in the frontend error object.
-                        return reason.length === 0 || reason.includes('workspace-backed session');
+                        if (typeof serverReason === 'string') {
+                            return serverReason.includes('workspace-backed session');
+                        }
+
+                        // Some service deployments currently return this rejection as an unstructured 400
+                        // without a JSON reason body, so we fall back to a workspace-backed launch.
+                        return true;
                     };
 
                     // `useEphemeralStorage` means "prefer ephemeral when possible".

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -223,27 +223,22 @@ function App(): JSX.Element {
             TheiaCloud.ping(PingRequest.create(config.serviceUrl, getServiceAuthToken(config)))
                 .then(() => {
                     // ping successful continue with launch
-                    let workspace: string | undefined;
+                    let workspace: string;
 
-                    if (config.useEphemeralStorage) {
-                        workspace = undefined;
-                        console.log(`Launching ${appDefinition} with ephemeral storage as configured`);
+                    if (!gitUri) {
+                        const fallbackWorkspaceId = Math.random().toString(36).substring(2, 10);
+                        workspace =
+                            'ws-' + appDefinition + '-playground-' + (config.useKeycloak ? username : user) + '-' + fallbackWorkspaceId;
+                        console.log(
+                            `Prepared persistent workspace ${workspace} for ${appDefinition} (playground fallback)`
+                        );
                     } else {
-                        if (!gitUri) {
-                            const fallbackWorkspaceId = Math.random().toString(36).substring(2, 10);
-                            workspace =
-                                'ws-' + appDefinition + '-playground-' + (config.useKeycloak ? username : user) + '-' + fallbackWorkspaceId;
-                            console.log(
-                                `Launching ${appDefinition} with persistent workspace ${workspace} (playground fallback)`
-                            );
-                        } else {
-                            // Artemis URLs look like: https://user@artemis.cit.tum.de/git/THEIATESTTESTEXERCISE/theiatesttestexercise-artemis_admin.git
-                            //                                                                                   ^^^^^^^^^^^^^^^^^^^^^ we need this part
-                            // First we split at the / character, get the last part, split at the - character and get the first part
-                            const repoName = gitUri?.split('/').pop()?.split('-')[0] ?? Math.random().toString().substring(2, 10);
-                            workspace = 'ws-' + appDefinition + '-' + repoName + '-' + (config.useKeycloak ? username : user);
-                            console.log(`Launching ${appDefinition} with persistent workspace ${workspace}`);
-                        }
+                        // Artemis URLs look like: https://user@artemis.cit.tum.de/git/THEIATESTTESTEXERCISE/theiatesttestexercise-artemis_admin.git
+                        //                                                                                   ^^^^^^^^^^^^^^^^^^^^^ we need this part
+                        // First we split at the / character, get the last part, split at the - character and get the first part
+                        const repoName = gitUri?.split('/').pop()?.split('-')[0] ?? Math.random().toString().substring(2, 10);
+                        workspace = 'ws-' + appDefinition + '-' + repoName + '-' + (config.useKeycloak ? username : user);
+                        console.log(`Prepared persistent workspace ${workspace} for ${appDefinition}`);
                     }
 
                     const requestOptions: RequestOptions = {
@@ -287,32 +282,67 @@ function App(): JSX.Element {
           });
         */
 
-                    const launchRequest = {
-                        serviceUrl: config.serviceUrl,
-                        appId: getServiceAuthToken(config),
-                        user: config.useKeycloak ? email! : user!,
-                        appDefinition: appDefinition,
-                        workspaceName: workspace,
-                        env: {
-                            fromMap: {
-                                THEIA: 'true',
-                                ARTEMIS_TOKEN: artemisToken!,
-                                ARTEMIS_URL: artemisUrl!,
-                                GIT_URI: gitUri!,
-                                GIT_USER: gitUser!,
-                                GIT_MAIL: gitMail!
-                            }
+                    const launchEnv = {
+                        fromMap: {
+                            THEIA: 'true',
+                            ARTEMIS_TOKEN: artemisToken!,
+                            ARTEMIS_URL: artemisUrl!,
+                            GIT_URI: gitUri!,
+                            GIT_USER: gitUser!,
+                            GIT_MAIL: gitMail!
                         }
-                    } satisfies LaunchRequest;
+                    };
+                    const launchUser = config.useKeycloak ? email! : user!;
+                    const serviceAuthToken = getServiceAuthToken(config);
+                    const createWorkspaceLaunchRequest = (): LaunchRequest => ({
+                        ...LaunchRequest.createWorkspace(
+                            config.serviceUrl,
+                            serviceAuthToken,
+                            appDefinition,
+                            undefined,
+                            launchUser,
+                            workspace
+                        ),
+                        env: launchEnv
+                    });
+                    const createEphemeralLaunchRequest = (): LaunchRequest => ({
+                        ...LaunchRequest.ephemeral(
+                            config.serviceUrl,
+                            serviceAuthToken,
+                            appDefinition,
+                            undefined,
+                            launchUser
+                        ),
+                        env: launchEnv
+                    });
 
-                    // TheiaCloud.launchAndRedirect(
-                    // config.useEphemeralStorage
-                    //  ? LaunchRequest.ephemeral(config.serviceUrl, config.appId, appDefinition, 5, email)
-                    //  : LaunchRequest.createWorkspace(config.serviceUrl, config.appId, appDefinition, 5, email, workspace),
+                    const isWorkspaceRequiredFallbackError = (err: Error): boolean =>
+                        (err as any)?.status === 400 &&
+                        typeof err.message === 'string' &&
+                        err.message.includes('workspace-backed session');
 
-                    // TheiaCloud.Session.list
+                    // `useEphemeralStorage` means "prefer ephemeral when possible".
+                    // App definitions that require a shared workspace are retried with a PVC-backed workspace.
+                    const launchPromise = config.useEphemeralStorage
+                        ? (() => {
+                            console.log(`Attempting ephemeral launch for ${appDefinition}`);
+                            return TheiaCloud.launchAndRedirect(createEphemeralLaunchRequest(), requestOptions).catch((err: Error) => {
+                                if (!isWorkspaceRequiredFallbackError(err)) {
+                                    throw err;
+                                }
 
-                    TheiaCloud.launchAndRedirect(launchRequest, requestOptions)
+                                console.log(
+                                    `Ephemeral launch for ${appDefinition} requires a shared workspace, retrying with ${workspace}`
+                                );
+                                return TheiaCloud.launchAndRedirect(createWorkspaceLaunchRequest(), requestOptions);
+                            });
+                        })()
+                        : (() => {
+                            console.log(`Launching ${appDefinition} with persistent workspace ${workspace}`);
+                            return TheiaCloud.launchAndRedirect(createWorkspaceLaunchRequest(), requestOptions);
+                        })();
+
+                    launchPromise
                         .catch((err: Error) => {
                             if (err && (err as any).status === 473) {
                                 setError(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -316,10 +316,18 @@ function App(): JSX.Element {
                         env: launchEnv
                     });
 
-                    const isWorkspaceRequiredFallbackError = (err: Error): boolean =>
-                        (err as any)?.status === 400 &&
-                        typeof err.message === 'string' &&
-                        err.message.includes('workspace-backed session');
+                    const isWorkspaceRequiredFallbackError = (err: Error): boolean => {
+                        const status = (err as any)?.status;
+                        const serverReason = (err as any)?.serverError?.reason;
+                        const reason =
+                            typeof serverReason === 'string'
+                                ? serverReason
+                                : typeof err.message === 'string'
+                                  ? err.message
+                                  : '';
+
+                        return status === 400 && reason.includes('workspace-backed session');
+                    };
 
                     // `useEphemeralStorage` means "prefer ephemeral when possible".
                     // App definitions that require a shared workspace are retried with a PVC-backed workspace.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,29 @@ let initialized = false;
 let initialAppName = '';
 let initialAppDefinition = '';
 let keycloakConfig: KeycloakConfig | undefined = undefined;
+const WORKSPACE_SEGMENT_LIMIT = 12;
+
+function createDeterministicId(value: string): string {
+    let hash = 0;
+
+    for (let i = 0; i < value.length; i += 1) {
+        hash = ((hash << 5) - hash) + value.charCodeAt(i);
+        hash |= 0;
+    }
+
+    return Math.abs(hash).toString(16).padStart(8, '0');
+}
+
+function sanitizeWorkspaceSegment(value: string | undefined, fallback: string): string {
+    const sanitized = (value ?? '')
+        .toLowerCase()
+        .replace(/[^a-z0-9-]/g, '-')
+        .replace(/^-+/, '')
+        .replace(/-+$/, '');
+
+    const normalized = sanitized.length > 0 ? sanitized : fallback;
+    return normalized.substring(0, Math.min(normalized.length, WORKSPACE_SEGMENT_LIMIT));
+}
 
 function App(): JSX.Element {
     const [config] = useState<ExtendedTheiaCloudConfig | undefined>(() => getTheiaCloudConfig());
@@ -224,20 +247,33 @@ function App(): JSX.Element {
                 .then(() => {
                     // ping successful continue with launch
                     let workspace: string;
+                    const workspaceUser = config.useKeycloak ? username : user;
+                    const workspaceUserSegment = sanitizeWorkspaceSegment(workspaceUser, 'user');
+                    const workspaceAppSegment = sanitizeWorkspaceSegment(appDefinition, 'app');
 
                     if (!gitUri) {
-                        const fallbackWorkspaceId = Math.random().toString(36).substring(2, 10);
                         workspace =
-                            'ws-' + appDefinition + '-playground-' + (config.useKeycloak ? username : user) + '-' + fallbackWorkspaceId;
+                            'ws-' +
+                            workspaceAppSegment +
+                            '-playground-' +
+                            workspaceUserSegment +
+                            '-' +
+                            createDeterministicId(`${workspaceUser}-${appDefinition}-playground`);
                         console.log(
                             `Prepared persistent workspace ${workspace} for ${appDefinition} (playground fallback)`
                         );
                     } else {
-                        // Artemis URLs look like: https://user@artemis.cit.tum.de/git/THEIATESTTESTEXERCISE/theiatesttestexercise-artemis_admin.git
-                        //                                                                                   ^^^^^^^^^^^^^^^^^^^^^ we need this part
-                        // First we split at the / character, get the last part, split at the - character and get the first part
-                        const repoName = gitUri?.split('/').pop()?.split('-')[0] ?? Math.random().toString().substring(2, 10);
-                        workspace = 'ws-' + appDefinition + '-' + repoName + '-' + (config.useKeycloak ? username : user);
+                        const repoName = gitUri.split('/').pop()?.replace(/\.git$/, '');
+                        const repoSegment = sanitizeWorkspaceSegment(repoName, 'repo');
+                        workspace =
+                            'ws-' +
+                            workspaceAppSegment +
+                            '-' +
+                            repoSegment +
+                            '-' +
+                            workspaceUserSegment +
+                            '-' +
+                            createDeterministicId(gitUri);
                         console.log(`Prepared persistent workspace ${workspace} for ${appDefinition}`);
                     }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -326,7 +326,13 @@ function App(): JSX.Element {
                                   ? err.message
                                   : '';
 
-                        return status === 400 && reason.includes('workspace-backed session');
+                        if (status !== 400) {
+                            return false;
+                        }
+
+                        // Some service deployments currently return an empty 400 body for this rejection,
+                        // so the backend reason is not always available in the frontend error object.
+                        return reason.length === 0 || reason.includes('workspace-backed session');
                     };
 
                     // `useEphemeralStorage` means "prefer ephemeral when possible".


### PR DESCRIPTION
## Summary
- make `useEphemeralStorage` mean "prefer ephemeral when possible" instead of implicitly relying on `workspaceName` being omitted
- send an explicit ephemeral `LaunchRequest` first when ephemeral mode is enabled
- retry with a workspace-backed launch when the backend rejects ephemeral launch because the app definition requires a shared workspace

## What changes
The landing page previously set `workspaceName` to `undefined` when `useEphemeralStorage` was enabled, but the `LaunchRequest` path does not infer ephemerality from a missing workspace name. As a result, the landing page could still end up on the workspace-backed launch path.

With this change:
- `useEphemeralStorage: false` always launches a workspace-backed session
- `useEphemeralStorage: true` first attempts an explicit ephemeral launch
- if the backend returns the shared-workspace `400` (`workspace-backed session`), the landing page retries once with a PVC-backed workspace launch

This matches the backend/operator behavior where app definitions with sidecars that mount the workspace cannot run ephemerally, while app definitions without that requirement can.

## Verification
- `npm run typecheck` in the original checkout
- `npm run build` in the original checkout

A second clean worktree was used to prepare the PR branch. That worktree does not have the local tool install on `PATH`, so `tsc` was not available there, but the same code had already passed verification in the original checkout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Session startup now always computes a deterministic workspace id, with a PVC-backed playground fallback when no repo is provided.
  * Launch request construction split into reusable pieces for environment, user selection, and workspace vs ephemeral creation.
  * Launch flow will try ephemeral storage first (when enabled) and automatically retry with persistent workspace on specific failures, with clearer logging and fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->