### PR TITLE
feat: add ai image selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ window.theiaCloudConfig = {
 | `additionalApps` | array | No | Additional apps to display |
 | `footerLinks` | object | No | Footer link configuration |
 
-Each entry in `additionalApps` may optionally include `image` (or `Image` for compatibility). When omitted, the landing page keeps the current behavior and derives the logo path from `appName`. Apps may also set `visible: false` to stay launchable through direct `appDef` URLs without appearing on the landing page. Visibility defaults to true and does not need to be configured for visible apps. When provided, the landing page uses the image value like this:
+Each entry in `additionalApps` may optionally include `image` (or `Image` for compatibility). When omitted, the landing page keeps the current behavior and derives the logo path from `appName`. Apps may also set `visible: false` to stay launchable through direct `appDef` URLs without appearing on the landing page. Set `aiVariant` to the app definition that should launch when the AI mode is selected; build-system choices are reused for the AI variant. Visibility defaults to true and does not need to be configured for visible apps. When provided, the landing page uses the image value like this:
 
 - Plain name like `java-17` becomes `/assets/logos/java-17-logo.png`
 - Filename like `java-17-logo.png` becomes `/assets/logos/java-17-logo.png`

--- a/public/config.js
+++ b/public/config.js
@@ -13,13 +13,14 @@ window.theiaCloudConfig = {
       appId: "c-latest",
       appName: "C",
       buildSystems: [
-        { id: "makefile", label: "Makefile"}
+        { id: "makefile", label: "Makefile" }
       ]
     },
     {
-      appId: "java-17-latest", 
-      appName: "Java",
-      image: "java-17",
+      appId: 'java-17-latest',
+      appName: 'Java',
+      image: 'java-17',
+      aiVariant: 'java-17-ai-latest',
       buildSystems: [
         { id: "maven", label: "Maven" },
         { id: "gradle", label: "Gradle" },
@@ -29,28 +30,28 @@ window.theiaCloudConfig = {
       appId: "javascript-latest",
       appName: "Javascript",
       buildSystems: [
-        { id: "npm", label: "npm"}
+        { id: "npm", label: "npm" }
       ]
     },
     {
       appId: "ocaml-latest",
       appName: "Ocaml",
       buildSystems: [
-        { id: "dune", label: "Dune"}
+        { id: "dune", label: "Dune" }
       ]
     },
     {
       appId: "python-latest",
       appName: "Python",
       buildSystems: [
-        { id: "pip", label: "pip"}
+        { id: "pip", label: "pip" }
       ]
     },
     {
       appId: "rust-latest",
       appName: "Rust",
       buildSystems: [
-        { id: "cargo", label: "Cargo"}
+        { id: "cargo", label: "Cargo" }
       ]
     }
   ],

--- a/public/config.js
+++ b/public/config.js
@@ -10,10 +10,10 @@ window.theiaCloudConfig = {
   pageTitle: 'EduIDE Cloud',
   additionalApps: [
     {
-      appId: "c-latest",
-      appName: "C",
+      appId: 'c-latest',
+      appName: 'C',
       buildSystems: [
-        { id: "makefile", label: "Makefile" }
+        { id: 'makefile', label: 'Makefile' }
       ]
     },
     {
@@ -22,36 +22,36 @@ window.theiaCloudConfig = {
       image: 'java-17',
       aiVariant: 'java-17-ai-latest',
       buildSystems: [
-        { id: "maven", label: "Maven" },
-        { id: "gradle", label: "Gradle" },
+        { id: 'maven', label: 'Maven' },
+        { id: 'gradle', label: 'Gradle' },
       ]
     },
     {
-      appId: "javascript-latest",
-      appName: "Javascript",
+      appId: 'javascript-latest',
+      appName: 'Javascript',
       buildSystems: [
-        { id: "npm", label: "npm" }
+        { id: 'npm', label: 'npm' }
       ]
     },
     {
-      appId: "ocaml-latest",
-      appName: "Ocaml",
+      appId: 'ocaml-latest',
+      appName: 'Ocaml',
       buildSystems: [
-        { id: "dune", label: "Dune" }
+        { id: 'dune', label: 'Dune' }
       ]
     },
     {
-      appId: "python-latest",
-      appName: "Python",
+      appId: 'python-latest',
+      appName: 'Python',
       buildSystems: [
-        { id: "pip", label: "pip" }
+        { id: 'pip', label: 'pip' }
       ]
     },
     {
-      appId: "rust-latest",
-      appName: "Rust",
+      appId: 'rust-latest',
+      appName: 'Rust',
       buildSystems: [
-        { id: "cargo", label: "Cargo" }
+        { id: 'cargo', label: 'Cargo' }
       ]
     }
   ],
@@ -87,8 +87,8 @@ window.theiaCloudConfig = {
   },
   // Keycloak configuration - only used when useKeycloak: true
   // For development, you can use a local Keycloak or minikube setup
-  // Example: "https://192.168.59.101.nip.io/keycloak" for minikube
-  keycloakAuthUrl: "http://localhost:8080/auth/",
-  keycloakRealm: "TheiaCloud",
-  keycloakClientId: "theia-cloud",
+  // Example: 'https://192.168.59.101.nip.io/keycloak' for minikube
+  keycloakAuthUrl: 'http://localhost:8080/auth/',
+  keycloakRealm: 'TheiaCloud',
+  keycloakClientId: 'theia-cloud',
 };

--- a/src/App.css
+++ b/src/App.css
@@ -76,7 +76,8 @@
     align-items: center;
     justify-content: flex-start;
     padding: 0px 20px 0px;
-    min-height: 0; /* Allow flex item to shrink */
+    min-height: 0;
+    /* Allow flex item to shrink */
 }
 
 .App__logo {
@@ -150,7 +151,7 @@
     padding: 24px;
 }
 
-.Build-System__list > * {
+.Build-System__list>* {
     flex: 0 1 150px;
 }
 
@@ -192,6 +193,13 @@
     transition: all 0.1s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+.App__grid-item--disabled,
+.App__grid-item:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
 .App__grid-item-logo {
     max-width: 60px;
     max-height: 60px;
@@ -217,6 +225,44 @@
     margin-bottom: 4px;
     text-transform: uppercase;
     letter-spacing: 1px;
+}
+
+.App__mode-selector {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 0.25rem;
+}
+
+.App__mode-selector-inner {
+    display: inline-flex;
+    background: var(--color-background-card);
+    border: 1px solid var(--color-border);
+    border-radius: 2rem;
+    padding: 3px;
+    gap: 2px;
+}
+
+.App__mode-selector-btn {
+    padding: 0.35rem 1.1rem;
+    background: transparent;
+    color: var(--color-text-muted);
+    border: none;
+    border-radius: 2rem;
+    font-family: 'Anonymous Pro', monospace;
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.App__mode-selector-btn:hover:not(.App__mode-selector-btn--active) {
+    color: var(--color-text-primary);
+}
+
+.App__mode-selector-btn--active {
+    background: var(--color-text-secondary);
+    color: var(--color-background);
 }
 
 .App__error-message {
@@ -272,9 +318,11 @@
     display: flex;
     align-items: center;
     justify-content: center;
+
     @media (min-width: 768px) {
         justify-content: flex-end;
     }
+
     gap: 0.5rem;
 }
 
@@ -315,9 +363,11 @@
 .App__footer__content {
     display: grid;
     grid-template-columns: repeat(1, minmax(0, 1fr));
+
     @media (min-width: 768px) {
         grid-template-columns: repeat(3, minmax(0, 1fr));
     }
+
     gap: 0.5rem;
     align-items: center;
     justify-content: space-between;
@@ -327,6 +377,7 @@
 .App__footer__attribution {
     font-size: 0.85rem;
     color: var(--color-text-muted);
+
     @media (min-width: 768px) {
         justify-self: start;
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -411,7 +411,7 @@ function App(): JSX.Element {
     const handleAppSelected = (appId: string, _: string): void => {
         const isStandaloneMode = !artemisToken && !gitUri;
         if (isStandaloneMode) {
-            const appDef = config.additionalApps?.find(a => (a.serviceAuthToken || a.appId) === appId);
+            const appDef = config.additionalApps?.find(a => (a.serviceAuthToken || a.appId) === appId || a.aiVariant === appId);
             const buildSystems = appDef?.buildSystems ?? [];
             if (buildSystems.length <= 1) {
                 handleStartSession(appId, buildSystems.length === 1 ? buildSystems[0].id : undefined);
@@ -506,7 +506,8 @@ function App(): JSX.Element {
     }
 
     const standaloneAppBuildSystems =
-        config.additionalApps?.find(a => (a.serviceAuthToken || a.appId) === standaloneAppDef)?.buildSystems ?? [];
+        config.additionalApps?.find(a => (a.serviceAuthToken || a.appId) === standaloneAppDef || a.aiVariant === standaloneAppDef)
+            ?.buildSystems ?? [];
 
     return (
         <div className='App'>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import Keycloak, { KeycloakConfig } from 'keycloak-js';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import type { ExtendedAppDefinition, ExtendedTheiaCloudConfig } from './common-extensions/types';
-import { getServiceAuthToken } from './common-extensions/types';
+import { AppMode, getServiceAuthToken } from './common-extensions/types';
 import { AppLogo } from './components/AppLogo';
 import { ErrorComponent } from './components/ErrorComponent';
 import { Footer } from './components/Footer';
@@ -27,546 +27,573 @@ let initialAppDefinition = '';
 let keycloakConfig: KeycloakConfig | undefined = undefined;
 const WORKSPACE_SEGMENT_LIMIT = 12;
 
+const APP_MODES: { value: AppMode; label: string }[] = [
+  { value: AppMode.Standard, label: 'Standard' },
+  { value: AppMode.AI, label: '✦ AI' }
+];
+
 function createDeterministicId(value: string): string {
-    let hash = 0;
+  let hash = 0;
 
-    for (let i = 0; i < value.length; i += 1) {
-        hash = (hash << 5) - hash + value.charCodeAt(i);
-        hash |= 0;
-    }
+  for (let i = 0; i < value.length; i += 1) {
+    hash = (hash << 5) - hash + value.charCodeAt(i);
+    hash |= 0;
+  }
 
-    return Math.abs(hash).toString(16).padStart(8, '0');
+  return Math.abs(hash).toString(16).padStart(8, '0');
 }
 
 function sanitizeWorkspaceSegment(value: string | undefined, fallback: string): string {
-    const sanitized = (value ?? '')
-        .toLowerCase()
-        .replace(/[^a-z0-9-]/g, '-')
-        .replace(/^-+/, '')
-        .replace(/-+$/, '');
+  const sanitized = (value ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/^-+/, '')
+    .replace(/-+$/, '');
 
-    const normalized = sanitized.length > 0 ? sanitized : fallback;
-    return normalized.substring(0, Math.min(normalized.length, WORKSPACE_SEGMENT_LIMIT));
+  const normalized = sanitized.length > 0 ? sanitized : fallback;
+  return normalized.substring(0, Math.min(normalized.length, WORKSPACE_SEGMENT_LIMIT));
 }
 
 function getCurrentRedirectUri(): string {
-    return window.location.href;
+  return window.location.href;
 }
 
 function App(): JSX.Element {
-    const [config] = useState<ExtendedTheiaCloudConfig | undefined>(() => getTheiaCloudConfig());
-    const [error, setError] = useState<string>();
-    const [loading, setLoading] = useState(false);
-    const [currentPage, setCurrentPage] = useState<'home' | 'imprint' | 'privacy'>('home');
+  const [config] = useState<ExtendedTheiaCloudConfig | undefined>(() => getTheiaCloudConfig());
+  const [error, setError] = useState<string>();
+  const [loading, setLoading] = useState(false);
+  const [currentPage, setCurrentPage] = useState<'home' | 'imprint' | 'privacy'>('home');
 
-    // Handle URL routing
-    useEffect(() => {
-        const updatePageFromUrl = (): void => {
-            const path = window.location.pathname;
-            if (path === '/imprint') {
-                setCurrentPage('imprint');
-            } else if (path === '/privacy') {
-                setCurrentPage('privacy');
-            } else {
-                setCurrentPage('home');
-            }
-        };
-
-        // Initial load
-        updatePageFromUrl();
-
-        // Listen for browser back/forward navigation
-        window.addEventListener('popstate', updatePageFromUrl);
-
-        return () => {
-            window.removeEventListener('popstate', updatePageFromUrl);
-        };
-    }, []);
-
-    // Navigation handler that updates both state and URL
-    const handleNavigation = (page: 'home' | 'imprint' | 'privacy'): void => {
-        const path = page === 'home' ? '/' : `/${page}`;
-
-        // Update URL without page reload
-        window.history.pushState({}, '', path);
-
-        // Update state
-        setCurrentPage(page);
+  // Handle URL routing
+  useEffect(() => {
+    const updatePageFromUrl = (): void => {
+      const path = window.location.pathname;
+      if (path === '/imprint') {
+        setCurrentPage('imprint');
+      } else if (path === '/privacy') {
+        setCurrentPage('privacy');
+      } else {
+        setCurrentPage('home');
+      }
     };
 
-    if (config === undefined) {
-        return (
-            <div className='App'>
-                <strong>FATAL: Theia Cloud configuration could not be found.</strong>
-            </div>
-        );
-    }
+    // Initial load
+    updatePageFromUrl();
 
-    if (!initialized) {
-        initialAppName = config.appName;
-        initialAppDefinition = config.appDefinition;
-    }
+    // Listen for browser back/forward navigation
+    window.addEventListener('popstate', updatePageFromUrl);
 
-    // ignore ESLint conditional rendering warnings.
-    // If config === undefined, this is an unremediable situation anyway.
-    /* eslint-disable react-hooks/rules-of-hooks */
-    const [selectedAppName, setSelectedAppName] = useState<string>(initialAppName);
-    const [selectedAppDefinition, setSelectedAppDefinition] = useState<string>(initialAppDefinition);
-
-    const [email, setEmail] = useState<string>();
-    const [username, setUsername] = useState<string>();
-    const [token, setToken] = useState<string>();
-    const [logoutUrl, setLogoutUrl] = useState<string>();
-    const [user, setUser] = useState<string>();
-
-    const [gitUri, setGitUri] = useState<string>();
-    const [gitUser, setGitUser] = useState<string>();
-    const [gitMail, setGitMail] = useState<string>();
-    const [artemisToken, setArtemisToken] = useState<string>();
-    const [artemisUrl, setArtemisUrl] = useState<string>();
-
-    const [autoStart, setAutoStart] = useState<boolean>(false);
-    const autoStartRequestedRef = useRef(false);
-
-    const [standaloneWizardStep, setStandaloneWizardStep] = useState<'language' | 'buildSystem'>('language');
-    const [standaloneAppDef, setStandaloneAppDef] = useState<string>();
-
-    if (!initialized) {
-        const urlParams = new URLSearchParams(window.location.search);
-
-        // Get appDef parameter from URL and set it as the default selection
-        if (urlParams.has('appDef') || urlParams.has('appdef')) {
-            const pathBlueprintSelection = urlParams.get('appDef') || urlParams.get('appdef');
-            if (
-                pathBlueprintSelection &&
-                isDefaultSelectionValueValid(pathBlueprintSelection, config.appDefinition, config.additionalApps)
-            ) {
-                if (config.additionalApps && config.additionalApps.length > 0) {
-                    const appDefinition = config.additionalApps.find(
-                        appDef => (appDef.serviceAuthToken || appDef.appId) === pathBlueprintSelection
-                    );
-                    setSelectedAppName(appDefinition ? appDefinition.appName : pathBlueprintSelection);
-                    setSelectedAppDefinition(
-                        appDefinition ? appDefinition.serviceAuthToken || appDefinition.appId : pathBlueprintSelection
-                    );
-                } else {
-                    setSelectedAppDefinition(pathBlueprintSelection);
-                    setSelectedAppName(pathBlueprintSelection);
-                }
-            } else {
-                setError('Invalid default selection value: ' + pathBlueprintSelection);
-                console.error('Invalid default selection value: ' + pathBlueprintSelection);
-            }
-        }
-
-        // Get gitUri parameter from URL.
-        if (urlParams.has('gitUri')) {
-            const gitUriParam = urlParams.get('gitUri');
-            if (gitUriParam) {
-                setGitUri(gitUriParam);
-            }
-        }
-
-        // Get artemisToken parameter from URL.
-        if (urlParams.has('artemisToken')) {
-            const artemisTokenParam = urlParams.get('artemisToken');
-            if (artemisTokenParam) {
-                setArtemisToken(artemisTokenParam);
-            }
-        }
-
-        // Get artemisUrl parameter from URL.
-        if (urlParams.has('artemisUrl')) {
-            const artemisUrlParam = urlParams.get('artemisUrl');
-            if (artemisUrlParam) {
-                setArtemisUrl(artemisUrlParam);
-            }
-        }
-
-        // Get gitUser parameter from URL.
-        if (urlParams.has('gitUser')) {
-            const gitUserParam = urlParams.get('gitUser');
-            if (gitUserParam) {
-                setGitUser(gitUserParam);
-            }
-        }
-
-        // Get gitMail parameter from URL.
-        if (urlParams.has('gitMail')) {
-            const gitMailParam = urlParams.get('gitMail');
-            if (gitMailParam) {
-                setGitMail(gitMailParam);
-            }
-        }
-
-        // Get user parameter from URL (for anonymous mode when Keycloak is disabled).
-        if (urlParams.has('user')) {
-            const userParam = urlParams.get('user');
-            if (userParam) {
-                setUser(userParam);
-            }
-        }
-
-        // Set default user for anonymous mode when Keycloak is disabled
-        if (!config.useKeycloak && !urlParams.has('user')) {
-            const randomId = Math.random().toString(36).substring(2, 10);
-            setUser(`anonymous-${randomId}`);
-        }
-
-        if (config.useKeycloak) {
-            keycloakConfig = {
-                url: config.keycloakAuthUrl,
-                realm: config.keycloakRealm!,
-                clientId: config.keycloakClientId!
-            };
-            const keycloak = new Keycloak(keycloakConfig);
-
-            keycloak
-                .init({
-                    onLoad: 'check-sso',
-                    redirectUri: getCurrentRedirectUri(),
-                    checkLoginIframe: false
-                })
-                .then(authenticated => {
-                    if (authenticated) {
-                        const parsedToken = keycloak.idTokenParsed;
-                        if (parsedToken) {
-                            const userMail = parsedToken.email;
-                            setToken(keycloak.idToken);
-                            setEmail(userMail);
-                            setUsername(parsedToken.preferred_username ?? userMail);
-                            setLogoutUrl(keycloak.createLogoutUrl());
-                        }
-                    }
-                })
-                .catch(() => {
-                    console.error('Authentication Failed');
-                });
-        }
-        initialized = true;
-    }
-
-    const handleStartSession = useCallback(
-        (appDefinition: string, buildSystemId?: string): void => {
-            setLoading(true);
-            setError(undefined);
-
-            TheiaCloud.ping(PingRequest.create(config.serviceUrl, getServiceAuthToken(config)))
-                .then(() => {
-                    // ping successful continue with launch
-                    let workspace: string;
-                    const workspaceUser = config.useKeycloak ? username : user;
-                    const workspaceUserSegment = sanitizeWorkspaceSegment(workspaceUser, 'user');
-                    const workspaceAppSegment = sanitizeWorkspaceSegment(appDefinition, 'app');
-
-                    if (!gitUri) {
-                        workspace =
-                            'ws-' +
-                            workspaceAppSegment +
-                            '-playground-' +
-                            workspaceUserSegment +
-                            '-' +
-                            createDeterministicId(`${workspaceUser}-${appDefinition}-playground`);
-                        console.log(`Prepared persistent workspace ${workspace} for ${appDefinition} (playground fallback)`);
-                    } else {
-                        const repoName = gitUri
-                            .split('/')
-                            .pop()
-                            ?.replace(/\.git$/, '');
-                        const repoSegment = sanitizeWorkspaceSegment(repoName, 'repo');
-                        workspace =
-                            'ws-' +
-                            workspaceAppSegment +
-                            '-' +
-                            repoSegment +
-                            '-' +
-                            workspaceUserSegment +
-                            '-' +
-                            createDeterministicId(gitUri);
-                        console.log(`Prepared persistent workspace ${workspace} for ${appDefinition}`);
-                    }
-
-                    const requestOptions: RequestOptions = {
-                        timeout: 60000,
-                        retries: 5,
-                        accessToken: token
-                    };
-
-                    const envFromMap: Record<string, string> = { THEIA: 'true' };
-                    if (artemisToken) {
-                        envFromMap.ARTEMIS_TOKEN = artemisToken;
-                    }
-                    if (artemisUrl) {
-                        envFromMap.ARTEMIS_URL = artemisUrl;
-                    }
-                    if (gitUri) {
-                        envFromMap.GIT_URI = gitUri;
-                    }
-                    if (gitUser) {
-                        envFromMap.GIT_USER = gitUser;
-                    }
-                    if (gitMail) {
-                        envFromMap.GIT_MAIL = gitMail;
-                    }
-                    if (buildSystemId) {
-                        envFromMap.TEMPLATE = buildSystemId;
-                    }
-
-                    const launchEnv = { fromMap: envFromMap };
-                    const launchUser = config.useKeycloak ? email! : user!;
-                    const serviceAuthToken = getServiceAuthToken(config);
-                    const createWorkspaceLaunchRequest = (): LaunchRequest => ({
-                        ...LaunchRequest.createWorkspace(
-                            config.serviceUrl,
-                            serviceAuthToken,
-                            appDefinition,
-                            undefined,
-                            launchUser,
-                            workspace
-                        ),
-                        env: launchEnv
-                    });
-                    const createEphemeralLaunchRequest = (): LaunchRequest => ({
-                        ...LaunchRequest.ephemeral(config.serviceUrl, serviceAuthToken, appDefinition, undefined, launchUser),
-                        env: launchEnv
-                    });
-
-                    const isWorkspaceRequiredFallbackError = (err: Error): boolean => {
-                        const status = (err as any)?.status;
-                        const serverReason = (err as any)?.serverError?.reason;
-                        const request = (err as any)?.request;
-
-                        if (status !== 400 || request?.kind !== LaunchRequest.KIND || request?.ephemeral !== true) {
-                            return false;
-                        }
-
-                        if (typeof serverReason === 'string') {
-                            return serverReason.includes('workspace-backed session');
-                        }
-
-                        // Some service deployments currently return this rejection as an unstructured 400
-                        // without a JSON reason body, so we fall back to a workspace-backed launch.
-                        return true;
-                    };
-
-                    // `useEphemeralStorage` means "prefer ephemeral when possible".
-                    // App definitions that require a shared workspace are retried with a PVC-backed workspace.
-                    // Template launches always use workspace-backed sessions so that env vars
-                    // are set directly on the container (eager/ephemeral sessions inject env
-                    // vars via data bridge which arrives after the entrypoint has already run).
-                    const launchPromise =
-                        config.useEphemeralStorage && !buildSystemId
-                            ? (() => {
-                                  console.log(`Attempting ephemeral launch for ${appDefinition}`);
-                                  return TheiaCloud.launchAndRedirect(createEphemeralLaunchRequest(), requestOptions).catch(
-                                      (err: Error) => {
-                                          if (!isWorkspaceRequiredFallbackError(err)) {
-                                              throw err;
-                                          }
-
-                                          console.log(
-                                              `Ephemeral launch for ${appDefinition} requires a shared workspace, retrying with ${workspace}`
-                                          );
-                                          return TheiaCloud.launchAndRedirect(createWorkspaceLaunchRequest(), requestOptions);
-                                      }
-                                  );
-                              })()
-                            : (() => {
-                                  console.log(`Launching ${appDefinition} with persistent workspace ${workspace}`);
-                                  return TheiaCloud.launchAndRedirect(createWorkspaceLaunchRequest(), requestOptions);
-                              })();
-
-                    launchPromise
-                        .catch((err: Error) => {
-                            if (err && (err as any).status === 473) {
-                                setError(
-                                    `The app definition '${appDefinition}' is not available in the cluster.\n` +
-                                        'Please try launching another application.'
-                                );
-                                return;
-                            }
-                            setError(err.message);
-                        })
-                        .finally(() => {
-                            setLoading(false);
-                        });
-                })
-                .catch((_err: Error) => {
-                    setError(
-                        'Sorry, we are performing some maintenance at the moment.\n' +
-                            "Please try again later. Usually maintenance won't last longer than 60 minutes.\n\n"
-                    );
-                    setLoading(false);
-                });
-        },
-        [config, gitUri, username, user, token, artemisToken, artemisUrl, gitUser, gitMail, email]
-    );
-
-    const handleAppSelected = (appId: string, _: string): void => {
-        const isStandaloneMode = !artemisToken && !gitUri;
-        if (isStandaloneMode) {
-            const appDef = config.additionalApps?.find(a => (a.serviceAuthToken || a.appId) === appId);
-            const buildSystems = appDef?.buildSystems ?? [];
-            if (buildSystems.length <= 1) {
-                handleStartSession(appId, buildSystems.length === 1 ? buildSystems[0].id : undefined);
-            } else {
-                setStandaloneAppDef(appId);
-                setStandaloneWizardStep('buildSystem');
-            }
-        } else {
-            handleStartSession(appId);
-        }
+    return () => {
+      window.removeEventListener('popstate', updatePageFromUrl);
     };
+  }, []);
 
-    useEffect(() => {
-        if (!initialized) {
-            return;
-        }
+  // Navigation handler that updates both state and URL
+  const handleNavigation = (page: 'home' | 'imprint' | 'privacy'): void => {
+    const path = page === 'home' ? '/' : `/${page}`;
 
-        if (config.useKeycloak && !username) {
-            autoStartRequestedRef.current = false;
-            return;
-        }
+    // Update URL without page reload
+    window.history.pushState({}, '', path);
 
-        if (selectedAppDefinition && gitUri && artemisToken) {
-            // authenticate();
-            setAutoStart(true);
-            if (!autoStartRequestedRef.current) {
-                autoStartRequestedRef.current = true;
-                handleStartSession(selectedAppDefinition);
-            }
-        } else {
-            autoStartRequestedRef.current = false;
-            setAutoStart(false);
-        }
-    }, [username, user, selectedAppDefinition, gitUri, artemisToken, handleStartSession, config.useKeycloak]);
+    // Update state
+    setCurrentPage(page);
+  };
 
-    /* eslint-enable react-hooks/rules-of-hooks */
-
-    document.title = config.pageTitle || 'EduIDE Cloud';
-
-    const authenticate: () => void = (): void => {
-        const keycloak = new Keycloak(keycloakConfig);
-
-        keycloak
-            .init({
-                redirectUri: getCurrentRedirectUri(),
-                checkLoginIframe: false
-            })
-            .then((authenticated: boolean) => {
-                if (!authenticated) {
-                    keycloak.login({
-                        redirectUri: getCurrentRedirectUri(),
-                        action: 'webauthn-register-passwordless:skip_if_exists'
-                    });
-                } else {
-                    const parsedToken = keycloak.idTokenParsed;
-                    if (parsedToken) {
-                        const userMail = parsedToken.email;
-                        setToken(keycloak.idToken);
-                        setEmail(userMail);
-                        setUsername(parsedToken.preferred_username ?? userMail);
-                        setLogoutUrl(keycloak.createLogoutUrl());
-                    }
-                }
-            })
-            .catch(() => {
-                console.error('Authentication Failed');
-                setError('Authentication failed');
-            });
-    };
-
-    const needsLogin = config.useKeycloak && !token;
-    const logoFileExtension = config.logoFileExtension ?? 'svg';
-
-    if (currentPage === 'imprint') {
-        return (
-            <div className='App'>
-                <VantaBackground>
-                    <Imprint onNavigate={handleNavigation} />
-                </VantaBackground>
-            </div>
-        );
-    }
-
-    if (currentPage === 'privacy') {
-        return (
-            <div className='App'>
-                <VantaBackground>
-                    <Privacy onNavigate={handleNavigation} />
-                </VantaBackground>
-            </div>
-        );
-    }
-
-    const standaloneAppBuildSystems =
-        config.additionalApps?.find(a => (a.serviceAuthToken || a.appId) === standaloneAppDef)?.buildSystems ?? [];
-
+  if (config === undefined) {
     return (
-        <div className='App'>
-            <VantaBackground>
-                <Header
-                    email={config.useKeycloak ? email : undefined}
-                    authenticate={config.useKeycloak ? authenticate : undefined}
-                    logoutUrl={config.useKeycloak ? logoutUrl : undefined}
-                />
-                <div className='body'>
-                    {loading ? (
-                        <Loading logoFileExtension={logoFileExtension} text={config.loadingText} />
-                    ) : (
-                        <div>
-                            <div>
-                                <div style={{ marginTop: '2rem' }}></div>
-                                <AppLogo fileExtension={logoFileExtension} />
-                                <h2 className='App__title'>
-                                    {standaloneWizardStep === 'buildSystem' ? 'Choose your build system' : 'Choose your Online IDE'}
-                                </h2>
-                                <div>
-                                    {needsLogin ? (
-                                        <LoginButton login={authenticate} />
-                                    ) : autoStart ? (
-                                        <LaunchApp
-                                            appName={selectedAppName}
-                                            appDefinition={selectedAppDefinition}
-                                            onStartSession={handleStartSession}
-                                        />
-                                    ) : standaloneWizardStep === 'buildSystem' ? (
-                                        <SelectBuildSystem
-                                            buildSystems={standaloneAppBuildSystems}
-                                            onSelect={buildSystemId => handleStartSession(standaloneAppDef!, buildSystemId)}
-                                            onBack={() => setStandaloneWizardStep('language')}
-                                        />
-                                    ) : (
-                                        <SelectApp appDefinitions={config.additionalApps} onSelectApp={handleAppSelected} />
-                                    )}
-                                </div>
-                            </div>
-                        </div>
-                    )}
-                    <ErrorComponent message={error} />
-                    {!error && !loading && (
-                        <Info usesLogin={config.useKeycloak} disable={config.disableInfo} text={config.infoText} title={config.infoTitle} />
-                    )}
-                </div>
-                <Footer
-                    selectedAppDefinition={autoStart ? selectedAppDefinition : ''}
-                    onNavigate={handleNavigation}
-                    footerLinks={config.footerLinks}
-                />
-            </VantaBackground>
-        </div>
+      <div className='App'>
+        <strong>FATAL: Theia Cloud configuration could not be found.</strong>
+      </div>
     );
+  }
+
+  if (!initialized) {
+    initialAppName = config.appName;
+    initialAppDefinition = config.appDefinition;
+  }
+
+  // ignore ESLint conditional rendering warnings.
+  // If config === undefined, this is an unremediable situation anyway.
+  /* eslint-disable react-hooks/rules-of-hooks */
+  const [selectedAppName, setSelectedAppName] = useState<string>(initialAppName);
+  const [selectedAppDefinition, setSelectedAppDefinition] = useState<string>(initialAppDefinition);
+  const [appMode, setAppMode] = useState<AppMode>(AppMode.Standard);
+
+  const [email, setEmail] = useState<string>();
+  const [username, setUsername] = useState<string>();
+  const [token, setToken] = useState<string>();
+  const [logoutUrl, setLogoutUrl] = useState<string>();
+  const [user, setUser] = useState<string>();
+
+  const [gitUri, setGitUri] = useState<string>();
+  const [gitUser, setGitUser] = useState<string>();
+  const [gitMail, setGitMail] = useState<string>();
+  const [artemisToken, setArtemisToken] = useState<string>();
+  const [artemisUrl, setArtemisUrl] = useState<string>();
+
+  const [autoStart, setAutoStart] = useState<boolean>(false);
+  const autoStartRequestedRef = useRef(false);
+
+  const [standaloneWizardStep, setStandaloneWizardStep] = useState<'language' | 'buildSystem'>('language');
+  const [standaloneAppDef, setStandaloneAppDef] = useState<string>();
+
+  if (!initialized) {
+    const urlParams = new URLSearchParams(window.location.search);
+
+    // Get appDef parameter from URL and set it as the default selection
+    if (urlParams.has('appDef') || urlParams.has('appdef')) {
+      const pathBlueprintSelection = urlParams.get('appDef') || urlParams.get('appdef');
+      if (
+        pathBlueprintSelection &&
+        isDefaultSelectionValueValid(pathBlueprintSelection, config.appDefinition, config.additionalApps)
+      ) {
+        if (config.additionalApps && config.additionalApps.length > 0) {
+          const appDefinition = config.additionalApps.find(
+            appDef => (appDef.serviceAuthToken || appDef.appId) === pathBlueprintSelection
+          );
+          setSelectedAppName(appDefinition ? appDefinition.appName : pathBlueprintSelection);
+          setSelectedAppDefinition(
+            appDefinition ? appDefinition.serviceAuthToken || appDefinition.appId : pathBlueprintSelection
+          );
+        } else {
+          setSelectedAppDefinition(pathBlueprintSelection);
+          setSelectedAppName(pathBlueprintSelection);
+        }
+      } else {
+        setError('Invalid default selection value: ' + pathBlueprintSelection);
+        console.error('Invalid default selection value: ' + pathBlueprintSelection);
+      }
+    }
+
+    // Get gitUri parameter from URL.
+    if (urlParams.has('gitUri')) {
+      const gitUriParam = urlParams.get('gitUri');
+      if (gitUriParam) {
+        setGitUri(gitUriParam);
+      }
+    }
+
+    // Get artemisToken parameter from URL.
+    if (urlParams.has('artemisToken')) {
+      const artemisTokenParam = urlParams.get('artemisToken');
+      if (artemisTokenParam) {
+        setArtemisToken(artemisTokenParam);
+      }
+    }
+
+    // Get artemisUrl parameter from URL.
+    if (urlParams.has('artemisUrl')) {
+      const artemisUrlParam = urlParams.get('artemisUrl');
+      if (artemisUrlParam) {
+        setArtemisUrl(artemisUrlParam);
+      }
+    }
+
+    // Get gitUser parameter from URL.
+    if (urlParams.has('gitUser')) {
+      const gitUserParam = urlParams.get('gitUser');
+      if (gitUserParam) {
+        setGitUser(gitUserParam);
+      }
+    }
+
+    // Get gitMail parameter from URL.
+    if (urlParams.has('gitMail')) {
+      const gitMailParam = urlParams.get('gitMail');
+      if (gitMailParam) {
+        setGitMail(gitMailParam);
+      }
+    }
+
+    // Get user parameter from URL (for anonymous mode when Keycloak is disabled).
+    if (urlParams.has('user')) {
+      const userParam = urlParams.get('user');
+      if (userParam) {
+        setUser(userParam);
+      }
+    }
+
+    // Set default user for anonymous mode when Keycloak is disabled
+    if (!config.useKeycloak && !urlParams.has('user')) {
+      const randomId = Math.random().toString(36).substring(2, 10);
+      setUser(`anonymous-${randomId}`);
+    }
+
+    if (config.useKeycloak) {
+      keycloakConfig = {
+        url: config.keycloakAuthUrl,
+        realm: config.keycloakRealm!,
+        clientId: config.keycloakClientId!
+      };
+      const keycloak = new Keycloak(keycloakConfig);
+
+      keycloak
+        .init({
+          onLoad: 'check-sso',
+          redirectUri: getCurrentRedirectUri(),
+          checkLoginIframe: false
+        })
+        .then(authenticated => {
+          if (authenticated) {
+            const parsedToken = keycloak.idTokenParsed;
+            if (parsedToken) {
+              const userMail = parsedToken.email;
+              setToken(keycloak.idToken);
+              setEmail(userMail);
+              setUsername(parsedToken.preferred_username ?? userMail);
+              setLogoutUrl(keycloak.createLogoutUrl());
+            }
+          }
+        })
+        .catch(() => {
+          console.error('Authentication Failed');
+        });
+    }
+    initialized = true;
+  }
+
+  const handleStartSession = useCallback(
+    (appDefinition: string, buildSystemId?: string): void => {
+      setLoading(true);
+      setError(undefined);
+
+      TheiaCloud.ping(PingRequest.create(config.serviceUrl, getServiceAuthToken(config)))
+        .then(() => {
+          // ping successful continue with launch
+          let workspace: string;
+          const workspaceUser = config.useKeycloak ? username : user;
+          const workspaceUserSegment = sanitizeWorkspaceSegment(workspaceUser, 'user');
+          const workspaceAppSegment = sanitizeWorkspaceSegment(appDefinition, 'app');
+
+          if (!gitUri) {
+            workspace =
+              'ws-' +
+              workspaceAppSegment +
+              '-playground-' +
+              workspaceUserSegment +
+              '-' +
+              createDeterministicId(`${workspaceUser}-${appDefinition}-playground`);
+            console.log(`Prepared persistent workspace ${workspace} for ${appDefinition} (playground fallback)`);
+          } else {
+            const repoName = gitUri
+              .split('/')
+              .pop()
+              ?.replace(/\.git$/, '');
+            const repoSegment = sanitizeWorkspaceSegment(repoName, 'repo');
+            workspace =
+              'ws-' +
+              workspaceAppSegment +
+              '-' +
+              repoSegment +
+              '-' +
+              workspaceUserSegment +
+              '-' +
+              createDeterministicId(gitUri);
+            console.log(`Prepared persistent workspace ${workspace} for ${appDefinition}`);
+          }
+
+          const requestOptions: RequestOptions = {
+            timeout: 60000,
+            retries: 5,
+            accessToken: token
+          };
+
+          const envFromMap: Record<string, string> = { THEIA: 'true' };
+          if (artemisToken) {
+            envFromMap.ARTEMIS_TOKEN = artemisToken;
+          }
+          if (artemisUrl) {
+            envFromMap.ARTEMIS_URL = artemisUrl;
+          }
+          if (gitUri) {
+            envFromMap.GIT_URI = gitUri;
+          }
+          if (gitUser) {
+            envFromMap.GIT_USER = gitUser;
+          }
+          if (gitMail) {
+            envFromMap.GIT_MAIL = gitMail;
+          }
+          if (buildSystemId) {
+            envFromMap.TEMPLATE = buildSystemId;
+          }
+
+          const launchEnv = { fromMap: envFromMap };
+          const launchUser = config.useKeycloak ? email! : user!;
+          const serviceAuthToken = getServiceAuthToken(config);
+          const createWorkspaceLaunchRequest = (): LaunchRequest => ({
+            ...LaunchRequest.createWorkspace(
+              config.serviceUrl,
+              serviceAuthToken,
+              appDefinition,
+              undefined,
+              launchUser,
+              workspace
+            ),
+            env: launchEnv
+          });
+          const createEphemeralLaunchRequest = (): LaunchRequest => ({
+            ...LaunchRequest.ephemeral(config.serviceUrl, serviceAuthToken, appDefinition, undefined, launchUser),
+            env: launchEnv
+          });
+
+          const isWorkspaceRequiredFallbackError = (err: Error): boolean => {
+            const status = (err as any)?.status;
+            const serverReason = (err as any)?.serverError?.reason;
+            const request = (err as any)?.request;
+
+            if (status !== 400 || request?.kind !== LaunchRequest.KIND || request?.ephemeral !== true) {
+              return false;
+            }
+
+            if (typeof serverReason === 'string') {
+              return serverReason.includes('workspace-backed session');
+            }
+
+            // Some service deployments currently return this rejection as an unstructured 400
+            // without a JSON reason body, so we fall back to a workspace-backed launch.
+            return true;
+          };
+
+          // `useEphemeralStorage` means "prefer ephemeral when possible".
+          // App definitions that require a shared workspace are retried with a PVC-backed workspace.
+          // Template launches always use workspace-backed sessions so that env vars
+          // are set directly on the container (eager/ephemeral sessions inject env
+          // vars via data bridge which arrives after the entrypoint has already run).
+          const launchPromise =
+            config.useEphemeralStorage && !buildSystemId
+              ? (() => {
+                console.log(`Attempting ephemeral launch for ${appDefinition}`);
+                return TheiaCloud.launchAndRedirect(createEphemeralLaunchRequest(), requestOptions).catch(
+                  (err: Error) => {
+                    if (!isWorkspaceRequiredFallbackError(err)) {
+                      throw err;
+                    }
+
+                    console.log(
+                      `Ephemeral launch for ${appDefinition} requires a shared workspace, retrying with ${workspace}`
+                    );
+                    return TheiaCloud.launchAndRedirect(createWorkspaceLaunchRequest(), requestOptions);
+                  }
+                );
+              })()
+              : (() => {
+                console.log(`Launching ${appDefinition} with persistent workspace ${workspace}`);
+                return TheiaCloud.launchAndRedirect(createWorkspaceLaunchRequest(), requestOptions);
+              })();
+
+          launchPromise
+            .catch((err: Error) => {
+              if (err && (err as any).status === 473) {
+                setError(
+                  `The app definition '${appDefinition}' is not available in the cluster.\n` +
+                  'Please try launching another application.'
+                );
+                return;
+              }
+              setError(err.message);
+            })
+            .finally(() => {
+              setLoading(false);
+            });
+        })
+        .catch((_err: Error) => {
+          setError(
+            'Sorry, we are performing some maintenance at the moment.\n' +
+            "Please try again later. Usually maintenance won't last longer than 60 minutes.\n\n"
+          );
+          setLoading(false);
+        });
+    },
+    [config, gitUri, username, user, token, artemisToken, artemisUrl, gitUser, gitMail, email]
+  );
+
+  const handleAppSelected = (appId: string, _: string): void => {
+    const isStandaloneMode = !artemisToken && !gitUri;
+    if (isStandaloneMode) {
+      const appDef = config.additionalApps?.find(a => (a.serviceAuthToken || a.appId) === appId);
+      const buildSystems = appDef?.buildSystems ?? [];
+      if (buildSystems.length <= 1) {
+        handleStartSession(appId, buildSystems.length === 1 ? buildSystems[0].id : undefined);
+      } else {
+        setStandaloneAppDef(appId);
+        setStandaloneWizardStep('buildSystem');
+      }
+    } else {
+      handleStartSession(appId);
+    }
+  };
+
+  useEffect(() => {
+    if (!initialized) {
+      return;
+    }
+
+    if (config.useKeycloak && !username) {
+      autoStartRequestedRef.current = false;
+      return;
+    }
+
+    if (selectedAppDefinition && gitUri && artemisToken) {
+      // authenticate();
+      setAutoStart(true);
+      if (!autoStartRequestedRef.current) {
+        autoStartRequestedRef.current = true;
+        handleStartSession(selectedAppDefinition);
+      }
+    } else {
+      autoStartRequestedRef.current = false;
+      setAutoStart(false);
+    }
+  }, [username, user, selectedAppDefinition, gitUri, artemisToken, handleStartSession, config.useKeycloak]);
+
+  /* eslint-enable react-hooks/rules-of-hooks */
+
+  document.title = config.pageTitle || 'EduIDE Cloud';
+
+  const authenticate: () => void = (): void => {
+    const keycloak = new Keycloak(keycloakConfig);
+
+    keycloak
+      .init({
+        redirectUri: getCurrentRedirectUri(),
+        checkLoginIframe: false
+      })
+      .then((authenticated: boolean) => {
+        if (!authenticated) {
+          keycloak.login({
+            redirectUri: getCurrentRedirectUri(),
+            action: 'webauthn-register-passwordless:skip_if_exists'
+          });
+        } else {
+          const parsedToken = keycloak.idTokenParsed;
+          if (parsedToken) {
+            const userMail = parsedToken.email;
+            setToken(keycloak.idToken);
+            setEmail(userMail);
+            setUsername(parsedToken.preferred_username ?? userMail);
+            setLogoutUrl(keycloak.createLogoutUrl());
+          }
+        }
+      })
+      .catch(() => {
+        console.error('Authentication Failed');
+        setError('Authentication failed');
+      });
+  };
+
+  const needsLogin = config.useKeycloak && !token;
+  const logoFileExtension = config.logoFileExtension ?? 'svg';
+
+  if (currentPage === 'imprint') {
+    return (
+      <div className='App'>
+        <VantaBackground>
+          <Imprint onNavigate={handleNavigation} />
+        </VantaBackground>
+      </div>
+    );
+  }
+
+  if (currentPage === 'privacy') {
+    return (
+      <div className='App'>
+        <VantaBackground>
+          <Privacy onNavigate={handleNavigation} />
+        </VantaBackground>
+      </div>
+    );
+  }
+
+  const standaloneAppBuildSystems =
+    config.additionalApps?.find(a => (a.serviceAuthToken || a.appId) === standaloneAppDef)?.buildSystems ?? [];
+
+  return (
+    <div className='App'>
+      <VantaBackground>
+        <Header
+          email={config.useKeycloak ? email : undefined}
+          authenticate={config.useKeycloak ? authenticate : undefined}
+          logoutUrl={config.useKeycloak ? logoutUrl : undefined}
+        />
+        <div className='body'>
+          {loading ? (
+            <Loading logoFileExtension={logoFileExtension} text={config.loadingText} />
+          ) : (
+            <div>
+              <div>
+                <div style={{ marginTop: '2rem' }}></div>
+                <AppLogo fileExtension={logoFileExtension} />
+                <h2 className='App__title'>
+                  {standaloneWizardStep === 'buildSystem' ? 'Choose your build system' : 'Choose your Online IDE'}
+                </h2>
+                <div>
+                  {needsLogin ? (
+                    <LoginButton login={authenticate} />
+                  ) : autoStart ? (
+                    <LaunchApp
+                      appName={selectedAppName}
+                      appDefinition={selectedAppDefinition}
+                      onStartSession={handleStartSession}
+                    />
+                  ) : standaloneWizardStep === 'buildSystem' ? (
+                    <SelectBuildSystem
+                      buildSystems={standaloneAppBuildSystems}
+                      onSelect={buildSystemId => handleStartSession(standaloneAppDef!, buildSystemId)}
+                      onBack={() => setStandaloneWizardStep('language')}
+                    />
+                  ) : (
+                    <>
+                      <div className='App__mode-selector'>
+                        <div className='App__mode-selector-inner'>
+                          {APP_MODES.map(mode => (
+                            <button
+                              key={mode.value}
+                              className={`App__mode-selector-btn${appMode === mode.value ? ' App__mode-selector-btn--active' : ''
+                                }`}
+                              onClick={() => setAppMode(mode.value)}
+                              aria-pressed={appMode === mode.value}
+                            >
+                              {mode.label}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                      <SelectApp
+                        appDefinitions={config.additionalApps}
+                        onSelectApp={handleStartSession}
+                        appMode={appMode}
+                      />
+                    </>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+          <ErrorComponent message={error} />
+          {!error && !loading && (
+            <Info usesLogin={config.useKeycloak} disable={config.disableInfo} text={config.infoText} title={config.infoTitle} />
+          )}
+        </div>
+        <Footer
+          selectedAppDefinition={autoStart ? selectedAppDefinition : ''}
+          onNavigate={handleNavigation}
+          footerLinks={config.footerLinks}
+        />
+      </VantaBackground>
+    </div>
+  );
 }
 
 function isDefaultSelectionValueValid(defaultSelection: string, appDefinition: string, additionalApps?: ExtendedAppDefinition[]): boolean {
-    if (defaultSelection === appDefinition) {
-        return true;
-    }
-    if (additionalApps && additionalApps.length > 0) {
-        return additionalApps.some(def => def.serviceAuthToken === defaultSelection);
-    }
-    // If there are no additional apps explicitly configured, we accept any app definition given via url parameter
+  if (defaultSelection === appDefinition) {
     return true;
+  }
+  if (additionalApps && additionalApps.length > 0) {
+    return additionalApps.some(def => def.serviceAuthToken === defaultSelection);
+  }
+  // If there are no additional apps explicitly configured, we accept any app definition given via url parameter
+  return true;
 }
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -149,12 +149,10 @@ function App(): JSX.Element {
             ) {
                 if (config.additionalApps && config.additionalApps.length > 0) {
                     const appDefinition = config.additionalApps.find(
-                        appDef => (appDef.serviceAuthToken || appDef.appId) === pathBlueprintSelection
+                        appDef => (appDef.serviceAuthToken || appDef.appId) === pathBlueprintSelection || appDef.aiVariant === pathBlueprintSelection
                     );
                     setSelectedAppName(appDefinition ? appDefinition.appName : pathBlueprintSelection);
-                    setSelectedAppDefinition(
-                        appDefinition ? appDefinition.serviceAuthToken || appDefinition.appId : pathBlueprintSelection
-                    );
+                    setSelectedAppDefinition(pathBlueprintSelection);
                 } else {
                     setSelectedAppDefinition(pathBlueprintSelection);
                     setSelectedAppName(pathBlueprintSelection);
@@ -592,7 +590,7 @@ function isDefaultSelectionValueValid(defaultSelection: string, appDefinition: s
         return true;
     }
     if (additionalApps && additionalApps.length > 0) {
-        return additionalApps.some(def => def.serviceAuthToken === defaultSelection);
+        return additionalApps.some(def => (def.serviceAuthToken || def.appId) === defaultSelection || def.aiVariant === defaultSelection);
     }
     // If there are no additional apps explicitly configured, we accept any app definition given via url parameter
     return true;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,572 +28,573 @@ let keycloakConfig: KeycloakConfig | undefined = undefined;
 const WORKSPACE_SEGMENT_LIMIT = 12;
 
 const APP_MODES: { value: AppMode; label: string }[] = [
-  { value: AppMode.Standard, label: 'Standard' },
-  { value: AppMode.AI, label: '✦ AI' }
+    { value: AppMode.Standard, label: 'Standard' },
+    { value: AppMode.AI, label: '✦ AI' }
 ];
 
 function createDeterministicId(value: string): string {
-  let hash = 0;
+    let hash = 0;
 
-  for (let i = 0; i < value.length; i += 1) {
-    hash = (hash << 5) - hash + value.charCodeAt(i);
-    hash |= 0;
-  }
+    for (let i = 0; i < value.length; i += 1) {
+        hash = (hash << 5) - hash + value.charCodeAt(i);
+        hash |= 0;
+    }
 
-  return Math.abs(hash).toString(16).padStart(8, '0');
+    return Math.abs(hash).toString(16).padStart(8, '0');
 }
 
 function sanitizeWorkspaceSegment(value: string | undefined, fallback: string): string {
-  const sanitized = (value ?? '')
-    .toLowerCase()
-    .replace(/[^a-z0-9-]/g, '-')
-    .replace(/^-+/, '')
-    .replace(/-+$/, '');
+    const sanitized = (value ?? '')
+        .toLowerCase()
+        .replace(/[^a-z0-9-]/g, '-')
+        .replace(/^-+/, '')
+        .replace(/-+$/, '');
 
-  const normalized = sanitized.length > 0 ? sanitized : fallback;
-  return normalized.substring(0, Math.min(normalized.length, WORKSPACE_SEGMENT_LIMIT));
+    const normalized = sanitized.length > 0 ? sanitized : fallback;
+    return normalized.substring(0, Math.min(normalized.length, WORKSPACE_SEGMENT_LIMIT));
 }
 
 function getCurrentRedirectUri(): string {
-  return window.location.href;
+    return window.location.href;
 }
 
 function App(): JSX.Element {
-  const [config] = useState<ExtendedTheiaCloudConfig | undefined>(() => getTheiaCloudConfig());
-  const [error, setError] = useState<string>();
-  const [loading, setLoading] = useState(false);
-  const [currentPage, setCurrentPage] = useState<'home' | 'imprint' | 'privacy'>('home');
+    const [config] = useState<ExtendedTheiaCloudConfig | undefined>(() => getTheiaCloudConfig());
+    const [error, setError] = useState<string>();
+    const [loading, setLoading] = useState(false);
+    const [currentPage, setCurrentPage] = useState<'home' | 'imprint' | 'privacy'>('home');
 
-  // Handle URL routing
-  useEffect(() => {
-    const updatePageFromUrl = (): void => {
-      const path = window.location.pathname;
-      if (path === '/imprint') {
-        setCurrentPage('imprint');
-      } else if (path === '/privacy') {
-        setCurrentPage('privacy');
-      } else {
-        setCurrentPage('home');
-      }
+    // Handle URL routing
+    useEffect(() => {
+        const updatePageFromUrl = (): void => {
+            const path = window.location.pathname;
+            if (path === '/imprint') {
+                setCurrentPage('imprint');
+            } else if (path === '/privacy') {
+                setCurrentPage('privacy');
+            } else {
+                setCurrentPage('home');
+            }
+        };
+
+        // Initial load
+        updatePageFromUrl();
+
+        // Listen for browser back/forward navigation
+        window.addEventListener('popstate', updatePageFromUrl);
+
+        return () => {
+            window.removeEventListener('popstate', updatePageFromUrl);
+        };
+    }, []);
+
+    // Navigation handler that updates both state and URL
+    const handleNavigation = (page: 'home' | 'imprint' | 'privacy'): void => {
+        const path = page === 'home' ? '/' : `/${page}`;
+
+        // Update URL without page reload
+        window.history.pushState({}, '', path);
+
+        // Update state
+        setCurrentPage(page);
     };
 
-    // Initial load
-    updatePageFromUrl();
+    if (config === undefined) {
+        return (
+            <div className='App'>
+                <strong>FATAL: Theia Cloud configuration could not be found.</strong>
+            </div>
+        );
+    }
 
-    // Listen for browser back/forward navigation
-    window.addEventListener('popstate', updatePageFromUrl);
+    if (!initialized) {
+        initialAppName = config.appName;
+        initialAppDefinition = config.appDefinition;
+    }
 
-    return () => {
-      window.removeEventListener('popstate', updatePageFromUrl);
-    };
-  }, []);
+    // ignore ESLint conditional rendering warnings.
+    // If config === undefined, this is an unremediable situation anyway.
+    /* eslint-disable react-hooks/rules-of-hooks */
+    const [selectedAppName, setSelectedAppName] = useState<string>(initialAppName);
+    const [selectedAppDefinition, setSelectedAppDefinition] = useState<string>(initialAppDefinition);
+    const [appMode, setAppMode] = useState<AppMode>(AppMode.Standard);
 
-  // Navigation handler that updates both state and URL
-  const handleNavigation = (page: 'home' | 'imprint' | 'privacy'): void => {
-    const path = page === 'home' ? '/' : `/${page}`;
+    const [email, setEmail] = useState<string>();
+    const [username, setUsername] = useState<string>();
+    const [token, setToken] = useState<string>();
+    const [logoutUrl, setLogoutUrl] = useState<string>();
+    const [user, setUser] = useState<string>();
 
-    // Update URL without page reload
-    window.history.pushState({}, '', path);
+    const [gitUri, setGitUri] = useState<string>();
+    const [gitUser, setGitUser] = useState<string>();
+    const [gitMail, setGitMail] = useState<string>();
+    const [artemisToken, setArtemisToken] = useState<string>();
+    const [artemisUrl, setArtemisUrl] = useState<string>();
 
-    // Update state
-    setCurrentPage(page);
-  };
+    const [autoStart, setAutoStart] = useState<boolean>(false);
+    const autoStartRequestedRef = useRef(false);
 
-  if (config === undefined) {
-    return (
-      <div className='App'>
-        <strong>FATAL: Theia Cloud configuration could not be found.</strong>
-      </div>
-    );
-  }
+    const [standaloneWizardStep, setStandaloneWizardStep] = useState<'language' | 'buildSystem'>('language');
+    const [standaloneAppDef, setStandaloneAppDef] = useState<string>();
 
-  if (!initialized) {
-    initialAppName = config.appName;
-    initialAppDefinition = config.appDefinition;
-  }
+    if (!initialized) {
+        const urlParams = new URLSearchParams(window.location.search);
 
-  // ignore ESLint conditional rendering warnings.
-  // If config === undefined, this is an unremediable situation anyway.
-  /* eslint-disable react-hooks/rules-of-hooks */
-  const [selectedAppName, setSelectedAppName] = useState<string>(initialAppName);
-  const [selectedAppDefinition, setSelectedAppDefinition] = useState<string>(initialAppDefinition);
-  const [appMode, setAppMode] = useState<AppMode>(AppMode.Standard);
-
-  const [email, setEmail] = useState<string>();
-  const [username, setUsername] = useState<string>();
-  const [token, setToken] = useState<string>();
-  const [logoutUrl, setLogoutUrl] = useState<string>();
-  const [user, setUser] = useState<string>();
-
-  const [gitUri, setGitUri] = useState<string>();
-  const [gitUser, setGitUser] = useState<string>();
-  const [gitMail, setGitMail] = useState<string>();
-  const [artemisToken, setArtemisToken] = useState<string>();
-  const [artemisUrl, setArtemisUrl] = useState<string>();
-
-  const [autoStart, setAutoStart] = useState<boolean>(false);
-  const autoStartRequestedRef = useRef(false);
-
-  const [standaloneWizardStep, setStandaloneWizardStep] = useState<'language' | 'buildSystem'>('language');
-  const [standaloneAppDef, setStandaloneAppDef] = useState<string>();
-
-  if (!initialized) {
-    const urlParams = new URLSearchParams(window.location.search);
-
-    // Get appDef parameter from URL and set it as the default selection
-    if (urlParams.has('appDef') || urlParams.has('appdef')) {
-      const pathBlueprintSelection = urlParams.get('appDef') || urlParams.get('appdef');
-      if (
-        pathBlueprintSelection &&
-        isDefaultSelectionValueValid(pathBlueprintSelection, config.appDefinition, config.additionalApps)
-      ) {
-        if (config.additionalApps && config.additionalApps.length > 0) {
-          const appDefinition = config.additionalApps.find(
-            appDef => (appDef.serviceAuthToken || appDef.appId) === pathBlueprintSelection
-          );
-          setSelectedAppName(appDefinition ? appDefinition.appName : pathBlueprintSelection);
-          setSelectedAppDefinition(
-            appDefinition ? appDefinition.serviceAuthToken || appDefinition.appId : pathBlueprintSelection
-          );
-        } else {
-          setSelectedAppDefinition(pathBlueprintSelection);
-          setSelectedAppName(pathBlueprintSelection);
+        // Get appDef parameter from URL and set it as the default selection
+        if (urlParams.has('appDef') || urlParams.has('appdef')) {
+            const pathBlueprintSelection = urlParams.get('appDef') || urlParams.get('appdef');
+            if (
+                pathBlueprintSelection &&
+                isDefaultSelectionValueValid(pathBlueprintSelection, config.appDefinition, config.additionalApps)
+            ) {
+                if (config.additionalApps && config.additionalApps.length > 0) {
+                    const appDefinition = config.additionalApps.find(
+                        appDef => (appDef.serviceAuthToken || appDef.appId) === pathBlueprintSelection
+                    );
+                    setSelectedAppName(appDefinition ? appDefinition.appName : pathBlueprintSelection);
+                    setSelectedAppDefinition(
+                        appDefinition ? appDefinition.serviceAuthToken || appDefinition.appId : pathBlueprintSelection
+                    );
+                } else {
+                    setSelectedAppDefinition(pathBlueprintSelection);
+                    setSelectedAppName(pathBlueprintSelection);
+                }
+            } else {
+                setError('Invalid default selection value: ' + pathBlueprintSelection);
+                console.error('Invalid default selection value: ' + pathBlueprintSelection);
+            }
         }
-      } else {
-        setError('Invalid default selection value: ' + pathBlueprintSelection);
-        console.error('Invalid default selection value: ' + pathBlueprintSelection);
-      }
-    }
 
-    // Get gitUri parameter from URL.
-    if (urlParams.has('gitUri')) {
-      const gitUriParam = urlParams.get('gitUri');
-      if (gitUriParam) {
-        setGitUri(gitUriParam);
-      }
-    }
-
-    // Get artemisToken parameter from URL.
-    if (urlParams.has('artemisToken')) {
-      const artemisTokenParam = urlParams.get('artemisToken');
-      if (artemisTokenParam) {
-        setArtemisToken(artemisTokenParam);
-      }
-    }
-
-    // Get artemisUrl parameter from URL.
-    if (urlParams.has('artemisUrl')) {
-      const artemisUrlParam = urlParams.get('artemisUrl');
-      if (artemisUrlParam) {
-        setArtemisUrl(artemisUrlParam);
-      }
-    }
-
-    // Get gitUser parameter from URL.
-    if (urlParams.has('gitUser')) {
-      const gitUserParam = urlParams.get('gitUser');
-      if (gitUserParam) {
-        setGitUser(gitUserParam);
-      }
-    }
-
-    // Get gitMail parameter from URL.
-    if (urlParams.has('gitMail')) {
-      const gitMailParam = urlParams.get('gitMail');
-      if (gitMailParam) {
-        setGitMail(gitMailParam);
-      }
-    }
-
-    // Get user parameter from URL (for anonymous mode when Keycloak is disabled).
-    if (urlParams.has('user')) {
-      const userParam = urlParams.get('user');
-      if (userParam) {
-        setUser(userParam);
-      }
-    }
-
-    // Set default user for anonymous mode when Keycloak is disabled
-    if (!config.useKeycloak && !urlParams.has('user')) {
-      const randomId = Math.random().toString(36).substring(2, 10);
-      setUser(`anonymous-${randomId}`);
-    }
-
-    if (config.useKeycloak) {
-      keycloakConfig = {
-        url: config.keycloakAuthUrl,
-        realm: config.keycloakRealm!,
-        clientId: config.keycloakClientId!
-      };
-      const keycloak = new Keycloak(keycloakConfig);
-
-      keycloak
-        .init({
-          onLoad: 'check-sso',
-          redirectUri: getCurrentRedirectUri(),
-          checkLoginIframe: false
-        })
-        .then(authenticated => {
-          if (authenticated) {
-            const parsedToken = keycloak.idTokenParsed;
-            if (parsedToken) {
-              const userMail = parsedToken.email;
-              setToken(keycloak.idToken);
-              setEmail(userMail);
-              setUsername(parsedToken.preferred_username ?? userMail);
-              setLogoutUrl(keycloak.createLogoutUrl());
+        // Get gitUri parameter from URL.
+        if (urlParams.has('gitUri')) {
+            const gitUriParam = urlParams.get('gitUri');
+            if (gitUriParam) {
+                setGitUri(gitUriParam);
             }
-          }
-        })
-        .catch(() => {
-          console.error('Authentication Failed');
-        });
+        }
+
+        // Get artemisToken parameter from URL.
+        if (urlParams.has('artemisToken')) {
+            const artemisTokenParam = urlParams.get('artemisToken');
+            if (artemisTokenParam) {
+                setArtemisToken(artemisTokenParam);
+            }
+        }
+
+        // Get artemisUrl parameter from URL.
+        if (urlParams.has('artemisUrl')) {
+            const artemisUrlParam = urlParams.get('artemisUrl');
+            if (artemisUrlParam) {
+                setArtemisUrl(artemisUrlParam);
+            }
+        }
+
+        // Get gitUser parameter from URL.
+        if (urlParams.has('gitUser')) {
+            const gitUserParam = urlParams.get('gitUser');
+            if (gitUserParam) {
+                setGitUser(gitUserParam);
+            }
+        }
+
+        // Get gitMail parameter from URL.
+        if (urlParams.has('gitMail')) {
+            const gitMailParam = urlParams.get('gitMail');
+            if (gitMailParam) {
+                setGitMail(gitMailParam);
+            }
+        }
+
+        // Get user parameter from URL (for anonymous mode when Keycloak is disabled).
+        if (urlParams.has('user')) {
+            const userParam = urlParams.get('user');
+            if (userParam) {
+                setUser(userParam);
+            }
+        }
+
+        // Set default user for anonymous mode when Keycloak is disabled
+        if (!config.useKeycloak && !urlParams.has('user')) {
+            const randomId = Math.random().toString(36).substring(2, 10);
+            setUser(`anonymous-${randomId}`);
+        }
+
+        if (config.useKeycloak) {
+            keycloakConfig = {
+                url: config.keycloakAuthUrl,
+                realm: config.keycloakRealm!,
+                clientId: config.keycloakClientId!
+            };
+            const keycloak = new Keycloak(keycloakConfig);
+
+            keycloak
+                .init({
+                    onLoad: 'check-sso',
+                    redirectUri: getCurrentRedirectUri(),
+                    checkLoginIframe: false
+                })
+                .then(authenticated => {
+                    if (authenticated) {
+                        const parsedToken = keycloak.idTokenParsed;
+                        if (parsedToken) {
+                            const userMail = parsedToken.email;
+                            setToken(keycloak.idToken);
+                            setEmail(userMail);
+                            setUsername(parsedToken.preferred_username ?? userMail);
+                            setLogoutUrl(keycloak.createLogoutUrl());
+                        }
+                    }
+                })
+                .catch(() => {
+                    console.error('Authentication Failed');
+                });
+        }
+        initialized = true;
     }
-    initialized = true;
-  }
 
-  const handleStartSession = useCallback(
-    (appDefinition: string, buildSystemId?: string): void => {
-      setLoading(true);
-      setError(undefined);
+    const handleStartSession = useCallback(
+        (appDefinition: string, buildSystemId?: string): void => {
+            setLoading(true);
+            setError(undefined);
 
-      TheiaCloud.ping(PingRequest.create(config.serviceUrl, getServiceAuthToken(config)))
-        .then(() => {
-          // ping successful continue with launch
-          let workspace: string;
-          const workspaceUser = config.useKeycloak ? username : user;
-          const workspaceUserSegment = sanitizeWorkspaceSegment(workspaceUser, 'user');
-          const workspaceAppSegment = sanitizeWorkspaceSegment(appDefinition, 'app');
+            TheiaCloud.ping(PingRequest.create(config.serviceUrl, getServiceAuthToken(config)))
+                .then(() => {
+                    // ping successful continue with launch
+                    let workspace: string;
+                    const workspaceUser = config.useKeycloak ? username : user;
+                    const workspaceUserSegment = sanitizeWorkspaceSegment(workspaceUser, 'user');
+                    const workspaceAppSegment = sanitizeWorkspaceSegment(appDefinition, 'app');
 
-          if (!gitUri) {
-            workspace =
-              'ws-' +
-              workspaceAppSegment +
-              '-playground-' +
-              workspaceUserSegment +
-              '-' +
-              createDeterministicId(`${workspaceUser}-${appDefinition}-playground`);
-            console.log(`Prepared persistent workspace ${workspace} for ${appDefinition} (playground fallback)`);
-          } else {
-            const repoName = gitUri
-              .split('/')
-              .pop()
-              ?.replace(/\.git$/, '');
-            const repoSegment = sanitizeWorkspaceSegment(repoName, 'repo');
-            workspace =
-              'ws-' +
-              workspaceAppSegment +
-              '-' +
-              repoSegment +
-              '-' +
-              workspaceUserSegment +
-              '-' +
-              createDeterministicId(gitUri);
-            console.log(`Prepared persistent workspace ${workspace} for ${appDefinition}`);
-          }
-
-          const requestOptions: RequestOptions = {
-            timeout: 60000,
-            retries: 5,
-            accessToken: token
-          };
-
-          const envFromMap: Record<string, string> = { THEIA: 'true' };
-          if (artemisToken) {
-            envFromMap.ARTEMIS_TOKEN = artemisToken;
-          }
-          if (artemisUrl) {
-            envFromMap.ARTEMIS_URL = artemisUrl;
-          }
-          if (gitUri) {
-            envFromMap.GIT_URI = gitUri;
-          }
-          if (gitUser) {
-            envFromMap.GIT_USER = gitUser;
-          }
-          if (gitMail) {
-            envFromMap.GIT_MAIL = gitMail;
-          }
-          if (buildSystemId) {
-            envFromMap.TEMPLATE = buildSystemId;
-          }
-
-          const launchEnv = { fromMap: envFromMap };
-          const launchUser = config.useKeycloak ? email! : user!;
-          const serviceAuthToken = getServiceAuthToken(config);
-          const createWorkspaceLaunchRequest = (): LaunchRequest => ({
-            ...LaunchRequest.createWorkspace(
-              config.serviceUrl,
-              serviceAuthToken,
-              appDefinition,
-              undefined,
-              launchUser,
-              workspace
-            ),
-            env: launchEnv
-          });
-          const createEphemeralLaunchRequest = (): LaunchRequest => ({
-            ...LaunchRequest.ephemeral(config.serviceUrl, serviceAuthToken, appDefinition, undefined, launchUser),
-            env: launchEnv
-          });
-
-          const isWorkspaceRequiredFallbackError = (err: Error): boolean => {
-            const status = (err as any)?.status;
-            const serverReason = (err as any)?.serverError?.reason;
-            const request = (err as any)?.request;
-
-            if (status !== 400 || request?.kind !== LaunchRequest.KIND || request?.ephemeral !== true) {
-              return false;
-            }
-
-            if (typeof serverReason === 'string') {
-              return serverReason.includes('workspace-backed session');
-            }
-
-            // Some service deployments currently return this rejection as an unstructured 400
-            // without a JSON reason body, so we fall back to a workspace-backed launch.
-            return true;
-          };
-
-          // `useEphemeralStorage` means "prefer ephemeral when possible".
-          // App definitions that require a shared workspace are retried with a PVC-backed workspace.
-          // Template launches always use workspace-backed sessions so that env vars
-          // are set directly on the container (eager/ephemeral sessions inject env
-          // vars via data bridge which arrives after the entrypoint has already run).
-          const launchPromise =
-            config.useEphemeralStorage && !buildSystemId
-              ? (() => {
-                console.log(`Attempting ephemeral launch for ${appDefinition}`);
-                return TheiaCloud.launchAndRedirect(createEphemeralLaunchRequest(), requestOptions).catch(
-                  (err: Error) => {
-                    if (!isWorkspaceRequiredFallbackError(err)) {
-                      throw err;
+                    if (!gitUri) {
+                        workspace =
+                            'ws-' +
+                            workspaceAppSegment +
+                            '-playground-' +
+                            workspaceUserSegment +
+                            '-' +
+                            createDeterministicId(`${workspaceUser}-${appDefinition}-playground`);
+                        console.log(`Prepared persistent workspace ${workspace} for ${appDefinition} (playground fallback)`);
+                    } else {
+                        const repoName = gitUri
+                            .split('/')
+                            .pop()
+                            ?.replace(/\.git$/, '');
+                        const repoSegment = sanitizeWorkspaceSegment(repoName, 'repo');
+                        workspace =
+                            'ws-' +
+                            workspaceAppSegment +
+                            '-' +
+                            repoSegment +
+                            '-' +
+                            workspaceUserSegment +
+                            '-' +
+                            createDeterministicId(gitUri);
+                        console.log(`Prepared persistent workspace ${workspace} for ${appDefinition}`);
                     }
 
-                    console.log(
-                      `Ephemeral launch for ${appDefinition} requires a shared workspace, retrying with ${workspace}`
+                    const requestOptions: RequestOptions = {
+                        timeout: 60000,
+                        retries: 5,
+                        accessToken: token
+                    };
+
+                    const envFromMap: Record<string, string> = { THEIA: 'true' };
+                    if (artemisToken) {
+                        envFromMap.ARTEMIS_TOKEN = artemisToken;
+                    }
+                    if (artemisUrl) {
+                        envFromMap.ARTEMIS_URL = artemisUrl;
+                    }
+                    if (gitUri) {
+                        envFromMap.GIT_URI = gitUri;
+                    }
+                    if (gitUser) {
+                        envFromMap.GIT_USER = gitUser;
+                    }
+                    if (gitMail) {
+                        envFromMap.GIT_MAIL = gitMail;
+                    }
+                    if (buildSystemId) {
+                        envFromMap.TEMPLATE = buildSystemId;
+                    }
+
+                    const launchEnv = { fromMap: envFromMap };
+                    const launchUser = config.useKeycloak ? email! : user!;
+                    const serviceAuthToken = getServiceAuthToken(config);
+                    const createWorkspaceLaunchRequest = (): LaunchRequest => ({
+                        ...LaunchRequest.createWorkspace(
+                            config.serviceUrl,
+                            serviceAuthToken,
+                            appDefinition,
+                            undefined,
+                            launchUser,
+                            workspace
+                        ),
+                        env: launchEnv
+                    });
+                    const createEphemeralLaunchRequest = (): LaunchRequest => ({
+                        ...LaunchRequest.ephemeral(config.serviceUrl, serviceAuthToken, appDefinition, undefined, launchUser),
+                        env: launchEnv
+                    });
+
+                    const isWorkspaceRequiredFallbackError = (err: Error): boolean => {
+                        const status = (err as any)?.status;
+                        const serverReason = (err as any)?.serverError?.reason;
+                        const request = (err as any)?.request;
+
+                        if (status !== 400 || request?.kind !== LaunchRequest.KIND || request?.ephemeral !== true) {
+                            return false;
+                        }
+
+                        if (typeof serverReason === 'string') {
+                            return serverReason.includes('workspace-backed session');
+                        }
+
+                        // Some service deployments currently return this rejection as an unstructured 400
+                        // without a JSON reason body, so we fall back to a workspace-backed launch.
+                        return true;
+                    };
+
+                    // `useEphemeralStorage` means "prefer ephemeral when possible".
+                    // App definitions that require a shared workspace are retried with a PVC-backed workspace.
+                    // Template launches always use workspace-backed sessions so that env vars
+                    // are set directly on the container (eager/ephemeral sessions inject env
+                    // vars via data bridge which arrives after the entrypoint has already run).
+                    const launchPromise =
+                        config.useEphemeralStorage && !buildSystemId
+                            ? (() => {
+                                  console.log(`Attempting ephemeral launch for ${appDefinition}`);
+                                  return TheiaCloud.launchAndRedirect(createEphemeralLaunchRequest(), requestOptions).catch(
+                                      (err: Error) => {
+                                          if (!isWorkspaceRequiredFallbackError(err)) {
+                                              throw err;
+                                          }
+
+                                          console.log(
+                                              `Ephemeral launch for ${appDefinition} requires a shared workspace, retrying with ${workspace}`
+                                          );
+                                          return TheiaCloud.launchAndRedirect(createWorkspaceLaunchRequest(), requestOptions);
+                                      }
+                                  );
+                              })()
+                            : (() => {
+                                  console.log(`Launching ${appDefinition} with persistent workspace ${workspace}`);
+                                  return TheiaCloud.launchAndRedirect(createWorkspaceLaunchRequest(), requestOptions);
+                              })();
+
+                    launchPromise
+                        .catch((err: Error) => {
+                            if (err && (err as any).status === 473) {
+                                setError(
+                                    `The app definition '${appDefinition}' is not available in the cluster.\n` +
+                                        'Please try launching another application.'
+                                );
+                                return;
+                            }
+                            setError(err.message);
+                        })
+                        .finally(() => {
+                            setLoading(false);
+                        });
+                })
+                .catch((_err: Error) => {
+                    setError(
+                        'Sorry, we are performing some maintenance at the moment.\n' +
+                            "Please try again later. Usually maintenance won't last longer than 60 minutes.\n\n"
                     );
-                    return TheiaCloud.launchAndRedirect(createWorkspaceLaunchRequest(), requestOptions);
-                  }
-                );
-              })()
-              : (() => {
-                console.log(`Launching ${appDefinition} with persistent workspace ${workspace}`);
-                return TheiaCloud.launchAndRedirect(createWorkspaceLaunchRequest(), requestOptions);
-              })();
+                    setLoading(false);
+                });
+        },
+        [config, gitUri, username, user, token, artemisToken, artemisUrl, gitUser, gitMail, email]
+    );
 
-          launchPromise
-            .catch((err: Error) => {
-              if (err && (err as any).status === 473) {
-                setError(
-                  `The app definition '${appDefinition}' is not available in the cluster.\n` +
-                  'Please try launching another application.'
-                );
-                return;
-              }
-              setError(err.message);
-            })
-            .finally(() => {
-              setLoading(false);
-            });
-        })
-        .catch((_err: Error) => {
-          setError(
-            'Sorry, we are performing some maintenance at the moment.\n' +
-            "Please try again later. Usually maintenance won't last longer than 60 minutes.\n\n"
-          );
-          setLoading(false);
-        });
-    },
-    [config, gitUri, username, user, token, artemisToken, artemisUrl, gitUser, gitMail, email]
-  );
-
-  const handleAppSelected = (appId: string, _: string): void => {
-    const isStandaloneMode = !artemisToken && !gitUri;
-    if (isStandaloneMode) {
-      const appDef = config.additionalApps?.find(a => (a.serviceAuthToken || a.appId) === appId);
-      const buildSystems = appDef?.buildSystems ?? [];
-      if (buildSystems.length <= 1) {
-        handleStartSession(appId, buildSystems.length === 1 ? buildSystems[0].id : undefined);
-      } else {
-        setStandaloneAppDef(appId);
-        setStandaloneWizardStep('buildSystem');
-      }
-    } else {
-      handleStartSession(appId);
-    }
-  };
-
-  useEffect(() => {
-    if (!initialized) {
-      return;
-    }
-
-    if (config.useKeycloak && !username) {
-      autoStartRequestedRef.current = false;
-      return;
-    }
-
-    if (selectedAppDefinition && gitUri && artemisToken) {
-      // authenticate();
-      setAutoStart(true);
-      if (!autoStartRequestedRef.current) {
-        autoStartRequestedRef.current = true;
-        handleStartSession(selectedAppDefinition);
-      }
-    } else {
-      autoStartRequestedRef.current = false;
-      setAutoStart(false);
-    }
-  }, [username, user, selectedAppDefinition, gitUri, artemisToken, handleStartSession, config.useKeycloak]);
-
-  /* eslint-enable react-hooks/rules-of-hooks */
-
-  document.title = config.pageTitle || 'EduIDE Cloud';
-
-  const authenticate: () => void = (): void => {
-    const keycloak = new Keycloak(keycloakConfig);
-
-    keycloak
-      .init({
-        redirectUri: getCurrentRedirectUri(),
-        checkLoginIframe: false
-      })
-      .then((authenticated: boolean) => {
-        if (!authenticated) {
-          keycloak.login({
-            redirectUri: getCurrentRedirectUri(),
-            action: 'webauthn-register-passwordless:skip_if_exists'
-          });
+    const handleAppSelected = (appId: string, _: string): void => {
+        const isStandaloneMode = !artemisToken && !gitUri;
+        if (isStandaloneMode) {
+            const appDef = config.additionalApps?.find(a => (a.serviceAuthToken || a.appId) === appId);
+            const buildSystems = appDef?.buildSystems ?? [];
+            if (buildSystems.length <= 1) {
+                handleStartSession(appId, buildSystems.length === 1 ? buildSystems[0].id : undefined);
+            } else {
+                setStandaloneAppDef(appId);
+                setStandaloneWizardStep('buildSystem');
+            }
         } else {
-          const parsedToken = keycloak.idTokenParsed;
-          if (parsedToken) {
-            const userMail = parsedToken.email;
-            setToken(keycloak.idToken);
-            setEmail(userMail);
-            setUsername(parsedToken.preferred_username ?? userMail);
-            setLogoutUrl(keycloak.createLogoutUrl());
-          }
+            handleStartSession(appId);
         }
-      })
-      .catch(() => {
-        console.error('Authentication Failed');
-        setError('Authentication failed');
-      });
-  };
+    };
 
-  const needsLogin = config.useKeycloak && !token;
-  const logoFileExtension = config.logoFileExtension ?? 'svg';
+    useEffect(() => {
+        if (!initialized) {
+            return;
+        }
 
-  if (currentPage === 'imprint') {
-    return (
-      <div className='App'>
-        <VantaBackground>
-          <Imprint onNavigate={handleNavigation} />
-        </VantaBackground>
-      </div>
-    );
-  }
+        if (config.useKeycloak && !username) {
+            autoStartRequestedRef.current = false;
+            return;
+        }
 
-  if (currentPage === 'privacy') {
-    return (
-      <div className='App'>
-        <VantaBackground>
-          <Privacy onNavigate={handleNavigation} />
-        </VantaBackground>
-      </div>
-    );
-  }
+        if (selectedAppDefinition && gitUri && artemisToken) {
+            // authenticate();
+            setAutoStart(true);
+            if (!autoStartRequestedRef.current) {
+                autoStartRequestedRef.current = true;
+                handleStartSession(selectedAppDefinition);
+            }
+        } else {
+            autoStartRequestedRef.current = false;
+            setAutoStart(false);
+        }
+    }, [username, user, selectedAppDefinition, gitUri, artemisToken, handleStartSession, config.useKeycloak]);
 
-  const standaloneAppBuildSystems =
-    config.additionalApps?.find(a => (a.serviceAuthToken || a.appId) === standaloneAppDef)?.buildSystems ?? [];
+    /* eslint-enable react-hooks/rules-of-hooks */
 
-  return (
-    <div className='App'>
-      <VantaBackground>
-        <Header
-          email={config.useKeycloak ? email : undefined}
-          authenticate={config.useKeycloak ? authenticate : undefined}
-          logoutUrl={config.useKeycloak ? logoutUrl : undefined}
-        />
-        <div className='body'>
-          {loading ? (
-            <Loading logoFileExtension={logoFileExtension} text={config.loadingText} />
-          ) : (
-            <div>
-              <div>
-                <div style={{ marginTop: '2rem' }}></div>
-                <AppLogo fileExtension={logoFileExtension} />
-                <h2 className='App__title'>
-                  {standaloneWizardStep === 'buildSystem' ? 'Choose your build system' : 'Choose your Online IDE'}
-                </h2>
-                <div>
-                  {needsLogin ? (
-                    <LoginButton login={authenticate} />
-                  ) : autoStart ? (
-                    <LaunchApp
-                      appName={selectedAppName}
-                      appDefinition={selectedAppDefinition}
-                      onStartSession={handleStartSession}
-                    />
-                  ) : standaloneWizardStep === 'buildSystem' ? (
-                    <SelectBuildSystem
-                      buildSystems={standaloneAppBuildSystems}
-                      onSelect={buildSystemId => handleStartSession(standaloneAppDef!, buildSystemId)}
-                      onBack={() => setStandaloneWizardStep('language')}
-                    />
-                  ) : (
-                    <>
-                      <div className='App__mode-selector'>
-                        <div className='App__mode-selector-inner'>
-                          {APP_MODES.map(mode => (
-                            <button
-                              key={mode.value}
-                              className={`App__mode-selector-btn${appMode === mode.value ? ' App__mode-selector-btn--active' : ''
-                                }`}
-                              onClick={() => setAppMode(mode.value)}
-                              aria-pressed={appMode === mode.value}
-                            >
-                              {mode.label}
-                            </button>
-                          ))}
-                        </div>
-                      </div>
-                      <SelectApp
-                        appDefinitions={config.additionalApps}
-                        onSelectApp={handleStartSession}
-                        appMode={appMode}
-                      />
-                    </>
-                  )}
-                </div>
-              </div>
+    document.title = config.pageTitle || 'EduIDE Cloud';
+
+    const authenticate: () => void = (): void => {
+        const keycloak = new Keycloak(keycloakConfig);
+
+        keycloak
+            .init({
+                redirectUri: getCurrentRedirectUri(),
+                checkLoginIframe: false
+            })
+            .then((authenticated: boolean) => {
+                if (!authenticated) {
+                    keycloak.login({
+                        redirectUri: getCurrentRedirectUri(),
+                        action: 'webauthn-register-passwordless:skip_if_exists'
+                    });
+                } else {
+                    const parsedToken = keycloak.idTokenParsed;
+                    if (parsedToken) {
+                        const userMail = parsedToken.email;
+                        setToken(keycloak.idToken);
+                        setEmail(userMail);
+                        setUsername(parsedToken.preferred_username ?? userMail);
+                        setLogoutUrl(keycloak.createLogoutUrl());
+                    }
+                }
+            })
+            .catch(() => {
+                console.error('Authentication Failed');
+                setError('Authentication failed');
+            });
+    };
+
+    const needsLogin = config.useKeycloak && !token;
+    const logoFileExtension = config.logoFileExtension ?? 'svg';
+
+    if (currentPage === 'imprint') {
+        return (
+            <div className='App'>
+                <VantaBackground>
+                    <Imprint onNavigate={handleNavigation} />
+                </VantaBackground>
             </div>
-          )}
-          <ErrorComponent message={error} />
-          {!error && !loading && (
-            <Info usesLogin={config.useKeycloak} disable={config.disableInfo} text={config.infoText} title={config.infoTitle} />
-          )}
+        );
+    }
+
+    if (currentPage === 'privacy') {
+        return (
+            <div className='App'>
+                <VantaBackground>
+                    <Privacy onNavigate={handleNavigation} />
+                </VantaBackground>
+            </div>
+        );
+    }
+
+    const standaloneAppBuildSystems =
+        config.additionalApps?.find(a => (a.serviceAuthToken || a.appId) === standaloneAppDef)?.buildSystems ?? [];
+
+    return (
+        <div className='App'>
+            <VantaBackground>
+                <Header
+                    email={config.useKeycloak ? email : undefined}
+                    authenticate={config.useKeycloak ? authenticate : undefined}
+                    logoutUrl={config.useKeycloak ? logoutUrl : undefined}
+                />
+                <div className='body'>
+                    {loading ? (
+                        <Loading logoFileExtension={logoFileExtension} text={config.loadingText} />
+                    ) : (
+                        <div>
+                            <div>
+                                <div style={{ marginTop: '2rem' }}></div>
+                                <AppLogo fileExtension={logoFileExtension} />
+                                <h2 className='App__title'>
+                                    {standaloneWizardStep === 'buildSystem' ? 'Choose your build system' : 'Choose your Online IDE'}
+                                </h2>
+                                <div>
+                                    {needsLogin ? (
+                                        <LoginButton login={authenticate} />
+                                    ) : autoStart ? (
+                                        <LaunchApp
+                                            appName={selectedAppName}
+                                            appDefinition={selectedAppDefinition}
+                                            onStartSession={handleStartSession}
+                                        />
+                                    ) : standaloneWizardStep === 'buildSystem' ? (
+                                        <SelectBuildSystem
+                                            buildSystems={standaloneAppBuildSystems}
+                                            onSelect={buildSystemId => handleStartSession(standaloneAppDef!, buildSystemId)}
+                                            onBack={() => setStandaloneWizardStep('language')}
+                                        />
+                                    ) : (
+                                        <>
+                                            <div className='App__mode-selector'>
+                                                <div className='App__mode-selector-inner'>
+                                                    {APP_MODES.map(mode => (
+                                                        <button
+                                                            key={mode.value}
+                                                            className={`App__mode-selector-btn${
+                                                                appMode === mode.value ? ' App__mode-selector-btn--active' : ''
+                                                            }`}
+                                                            onClick={() => setAppMode(mode.value)}
+                                                            aria-pressed={appMode === mode.value}
+                                                        >
+                                                            {mode.label}
+                                                        </button>
+                                                    ))}
+                                                </div>
+                                            </div>
+                                            <SelectApp
+                                                appDefinitions={config.additionalApps}
+                                                onSelectApp={handleAppSelected}
+                                                appMode={appMode}
+                                            />
+                                        </>
+                                    )}
+                                </div>
+                            </div>
+                        </div>
+                    )}
+                    <ErrorComponent message={error} />
+                    {!error && !loading && (
+                        <Info usesLogin={config.useKeycloak} disable={config.disableInfo} text={config.infoText} title={config.infoTitle} />
+                    )}
+                </div>
+                <Footer
+                    selectedAppDefinition={autoStart ? selectedAppDefinition : ''}
+                    onNavigate={handleNavigation}
+                    footerLinks={config.footerLinks}
+                />
+            </VantaBackground>
         </div>
-        <Footer
-          selectedAppDefinition={autoStart ? selectedAppDefinition : ''}
-          onNavigate={handleNavigation}
-          footerLinks={config.footerLinks}
-        />
-      </VantaBackground>
-    </div>
-  );
+    );
 }
 
 function isDefaultSelectionValueValid(defaultSelection: string, appDefinition: string, additionalApps?: ExtendedAppDefinition[]): boolean {
-  if (defaultSelection === appDefinition) {
+    if (defaultSelection === appDefinition) {
+        return true;
+    }
+    if (additionalApps && additionalApps.length > 0) {
+        return additionalApps.some(def => def.serviceAuthToken === defaultSelection);
+    }
+    // If there are no additional apps explicitly configured, we accept any app definition given via url parameter
     return true;
-  }
-  if (additionalApps && additionalApps.length > 0) {
-    return additionalApps.some(def => def.serviceAuthToken === defaultSelection);
-  }
-  // If there are no additional apps explicitly configured, we accept any app definition given via url parameter
-  return true;
 }
 
 export default App;

--- a/src/common-extensions/types.ts
+++ b/src/common-extensions/types.ts
@@ -2,49 +2,48 @@
  * Local type extensions for @eclipse-theiacloud/common
  * These extend the npm package types with EduIDE-specific functionality
  */
+import type { AppDefinition, TheiaCloudConfig } from '@eclipse-theiacloud/common';
 
 export enum AppMode {
-    Standard = 'standard',
-    AI = 'ai'
+  Standard = 'standard',
+  AI = 'ai'
 }
-
-import type { AppDefinition, TheiaCloudConfig } from '@eclipse-theiacloud/common';
 
 /**
  * Footer link configuration structure
  */
 export interface FooterLinksConfig {
-    attribution?: {
-        text?: string;
-        url?: string;
-        version?: string;
-    };
-    bugReport?: {
-        text: string;
-        url: string;
-        target?: string;
-        rel?: string;
-    };
-    featureRequest?: {
-        text: string;
-        url: string;
-        target?: string;
-        rel?: string;
-    };
-    about?: {
-        text: string;
-        url: string;
-        target?: string;
-        rel?: string;
-    };
+  attribution?: {
+    text?: string;
+    url?: string;
+    version?: string;
+  };
+  bugReport?: {
+    text: string;
+    url: string;
+    target?: string;
+    rel?: string;
+  };
+  featureRequest?: {
+    text: string;
+    url: string;
+    target?: string;
+    rel?: string;
+  };
+  about?: {
+    text: string;
+    url: string;
+    target?: string;
+    rel?: string;
+  };
 }
 
 /**
  * A single build system option for a language app
  */
 export interface BuildSystemOption {
-    id: string;
-    label: string;
+  id: string;
+  label: string;
 }
 
 /**
@@ -52,12 +51,12 @@ export interface BuildSystemOption {
  * Bridges the gap between the package's ServiceConfig and legacy usage
  */
 export type ExtendedAppDefinition = AppDefinition & {
-    serviceAuthToken?: string;
-    buildSystems?: BuildSystemOption[];
-    image?: string;
-    Image?: string;
-    visible?: boolean;
-    aiVariant?: string;
+  serviceAuthToken?: string;
+  buildSystems?: BuildSystemOption[];
+  image?: string;
+  Image?: string;
+  visible?: boolean;
+  aiVariant?: string;
 };
 
 /**
@@ -65,12 +64,12 @@ export type ExtendedAppDefinition = AppDefinition & {
  * Uses intersection type since TheiaCloudConfig is a type alias
  */
 export type ExtendedTheiaCloudConfig = Omit<TheiaCloudConfig, 'additionalApps'> & {
-    additionalApps?: ExtendedAppDefinition[];
-    footerLinks?: FooterLinksConfig;
-    pageTitle?: string;
-    sentryEnable?: boolean;
-    sentryEnvironment?: string;
-    sentryDsn?: string;
+  additionalApps?: ExtendedAppDefinition[];
+  footerLinks?: FooterLinksConfig;
+  pageTitle?: string;
+  sentryEnable?: boolean;
+  sentryEnvironment?: string;
+  sentryDsn?: string;
 };
 
 /**
@@ -78,11 +77,11 @@ export type ExtendedTheiaCloudConfig = Omit<TheiaCloudConfig, 'additionalApps'> 
  * Handles both 'appId' (from npm package) and 'serviceAuthToken' (legacy)
  */
 export function getServiceAuthToken(config: TheiaCloudConfig | ExtendedTheiaCloudConfig | ExtendedAppDefinition): string {
-    if ('serviceAuthToken' in config && typeof config.serviceAuthToken === 'string') {
-        return config.serviceAuthToken;
-    }
-    if ('appId' in config && typeof config.appId === 'string') {
-        return config.appId;
-    }
-    throw new Error('Unable to extract service auth token from config');
+  if ('serviceAuthToken' in config && typeof config.serviceAuthToken === 'string') {
+    return config.serviceAuthToken;
+  }
+  if ('appId' in config && typeof config.appId === 'string') {
+    return config.appId;
+  }
+  throw new Error('Unable to extract service auth token from config');
 }

--- a/src/common-extensions/types.ts
+++ b/src/common-extensions/types.ts
@@ -3,43 +3,48 @@
  * These extend the npm package types with EduIDE-specific functionality
  */
 
+export enum AppMode {
+  Standard = 'standard',
+  AI = 'ai'
+}
+
 import type { AppDefinition, TheiaCloudConfig } from '@eclipse-theiacloud/common';
 
 /**
  * Footer link configuration structure
  */
 export interface FooterLinksConfig {
-    attribution?: {
-        text?: string;
-        url?: string;
-        version?: string;
-    };
-    bugReport?: {
-        text: string;
-        url: string;
-        target?: string;
-        rel?: string;
-    };
-    featureRequest?: {
-        text: string;
-        url: string;
-        target?: string;
-        rel?: string;
-    };
-    about?: {
-        text: string;
-        url: string;
-        target?: string;
-        rel?: string;
-    };
+  attribution?: {
+    text?: string;
+    url?: string;
+    version?: string;
+  };
+  bugReport?: {
+    text: string;
+    url: string;
+    target?: string;
+    rel?: string;
+  };
+  featureRequest?: {
+    text: string;
+    url: string;
+    target?: string;
+    rel?: string;
+  };
+  about?: {
+    text: string;
+    url: string;
+    target?: string;
+    rel?: string;
+  };
 }
 
 /**
  * A single build system option for a language app
  */
 export interface BuildSystemOption {
-    id: string;
-    label: string;
+  id: string;
+  label: string;
 }
 
 /**
@@ -47,11 +52,12 @@ export interface BuildSystemOption {
  * Bridges the gap between the package's ServiceConfig and legacy usage
  */
 export type ExtendedAppDefinition = AppDefinition & {
-    serviceAuthToken?: string;
-    buildSystems?: BuildSystemOption[];
-    image?: string;
-    Image?: string;
-    visible?: boolean;
+  serviceAuthToken?: string;
+  buildSystems?: BuildSystemOption[];
+  image?: string;
+  Image?: string;
+  visible?: boolean;
+  aiVariant?: string;
 };
 
 /**
@@ -59,12 +65,12 @@ export type ExtendedAppDefinition = AppDefinition & {
  * Uses intersection type since TheiaCloudConfig is a type alias
  */
 export type ExtendedTheiaCloudConfig = Omit<TheiaCloudConfig, 'additionalApps'> & {
-    additionalApps?: ExtendedAppDefinition[];
-    footerLinks?: FooterLinksConfig;
-    pageTitle?: string;
-    sentryEnable?: boolean;
-    sentryEnvironment?: string;
-    sentryDsn?: string;
+  additionalApps?: ExtendedAppDefinition[];
+  footerLinks?: FooterLinksConfig;
+  pageTitle?: string;
+  sentryEnable?: boolean;
+  sentryEnvironment?: string;
+  sentryDsn?: string;
 };
 
 /**
@@ -72,11 +78,11 @@ export type ExtendedTheiaCloudConfig = Omit<TheiaCloudConfig, 'additionalApps'> 
  * Handles both 'appId' (from npm package) and 'serviceAuthToken' (legacy)
  */
 export function getServiceAuthToken(config: TheiaCloudConfig | ExtendedTheiaCloudConfig | ExtendedAppDefinition): string {
-    if ('serviceAuthToken' in config && typeof config.serviceAuthToken === 'string') {
-        return config.serviceAuthToken;
-    }
-    if ('appId' in config && typeof config.appId === 'string') {
-        return config.appId;
-    }
-    throw new Error('Unable to extract service auth token from config');
+  if ('serviceAuthToken' in config && typeof config.serviceAuthToken === 'string') {
+    return config.serviceAuthToken;
+  }
+  if ('appId' in config && typeof config.appId === 'string') {
+    return config.appId;
+  }
+  throw new Error('Unable to extract service auth token from config');
 }

--- a/src/common-extensions/types.ts
+++ b/src/common-extensions/types.ts
@@ -4,8 +4,8 @@
  */
 
 export enum AppMode {
-  Standard = 'standard',
-  AI = 'ai'
+    Standard = 'standard',
+    AI = 'ai'
 }
 
 import type { AppDefinition, TheiaCloudConfig } from '@eclipse-theiacloud/common';
@@ -14,37 +14,37 @@ import type { AppDefinition, TheiaCloudConfig } from '@eclipse-theiacloud/common
  * Footer link configuration structure
  */
 export interface FooterLinksConfig {
-  attribution?: {
-    text?: string;
-    url?: string;
-    version?: string;
-  };
-  bugReport?: {
-    text: string;
-    url: string;
-    target?: string;
-    rel?: string;
-  };
-  featureRequest?: {
-    text: string;
-    url: string;
-    target?: string;
-    rel?: string;
-  };
-  about?: {
-    text: string;
-    url: string;
-    target?: string;
-    rel?: string;
-  };
+    attribution?: {
+        text?: string;
+        url?: string;
+        version?: string;
+    };
+    bugReport?: {
+        text: string;
+        url: string;
+        target?: string;
+        rel?: string;
+    };
+    featureRequest?: {
+        text: string;
+        url: string;
+        target?: string;
+        rel?: string;
+    };
+    about?: {
+        text: string;
+        url: string;
+        target?: string;
+        rel?: string;
+    };
 }
 
 /**
  * A single build system option for a language app
  */
 export interface BuildSystemOption {
-  id: string;
-  label: string;
+    id: string;
+    label: string;
 }
 
 /**
@@ -52,12 +52,12 @@ export interface BuildSystemOption {
  * Bridges the gap between the package's ServiceConfig and legacy usage
  */
 export type ExtendedAppDefinition = AppDefinition & {
-  serviceAuthToken?: string;
-  buildSystems?: BuildSystemOption[];
-  image?: string;
-  Image?: string;
-  visible?: boolean;
-  aiVariant?: string;
+    serviceAuthToken?: string;
+    buildSystems?: BuildSystemOption[];
+    image?: string;
+    Image?: string;
+    visible?: boolean;
+    aiVariant?: string;
 };
 
 /**
@@ -65,12 +65,12 @@ export type ExtendedAppDefinition = AppDefinition & {
  * Uses intersection type since TheiaCloudConfig is a type alias
  */
 export type ExtendedTheiaCloudConfig = Omit<TheiaCloudConfig, 'additionalApps'> & {
-  additionalApps?: ExtendedAppDefinition[];
-  footerLinks?: FooterLinksConfig;
-  pageTitle?: string;
-  sentryEnable?: boolean;
-  sentryEnvironment?: string;
-  sentryDsn?: string;
+    additionalApps?: ExtendedAppDefinition[];
+    footerLinks?: FooterLinksConfig;
+    pageTitle?: string;
+    sentryEnable?: boolean;
+    sentryEnvironment?: string;
+    sentryDsn?: string;
 };
 
 /**
@@ -78,11 +78,11 @@ export type ExtendedTheiaCloudConfig = Omit<TheiaCloudConfig, 'additionalApps'> 
  * Handles both 'appId' (from npm package) and 'serviceAuthToken' (legacy)
  */
 export function getServiceAuthToken(config: TheiaCloudConfig | ExtendedTheiaCloudConfig | ExtendedAppDefinition): string {
-  if ('serviceAuthToken' in config && typeof config.serviceAuthToken === 'string') {
-    return config.serviceAuthToken;
-  }
-  if ('appId' in config && typeof config.appId === 'string') {
-    return config.appId;
-  }
-  throw new Error('Unable to extract service auth token from config');
+    if ('serviceAuthToken' in config && typeof config.serviceAuthToken === 'string') {
+        return config.serviceAuthToken;
+    }
+    if ('appId' in config && typeof config.appId === 'string') {
+        return config.appId;
+    }
+    throw new Error('Unable to extract service auth token from config');
 }

--- a/src/components/SelectApp.tsx
+++ b/src/components/SelectApp.tsx
@@ -1,52 +1,58 @@
 import React from 'react';
 
 import type { ExtendedAppDefinition } from '../common-extensions/types';
+import { AppMode } from '../common-extensions/types';
 
 interface SelectAppProps {
-    appDefinitions: ExtendedAppDefinition[] | undefined;
-    onSelectApp: (appId: string, appName: string) => void;
+  appDefinitions: ExtendedAppDefinition[] | undefined;
+  onSelectApp: (appId: string, appName: string) => void;
+  appMode: AppMode;
 }
 
 function normalizeLogoName(value: string): string {
-    return value.trim().toLowerCase().replace(/\s+/g, '-');
+  return value.trim().toLowerCase().replace(/\s+/g, '-');
 }
 
 function getAppLogoSrc(app: ExtendedAppDefinition): string {
-    const configuredImage = app.image ?? app.Image;
+  const configuredImage = app.image ?? app.Image;
 
-    if (!configuredImage || configuredImage.trim().length === 0) {
-        return `/assets/logos/${normalizeLogoName(app.appName)}-logo.png`;
-    }
+  if (!configuredImage || configuredImage.trim().length === 0) {
+    return `/assets/logos/${normalizeLogoName(app.appName)}-logo.png`;
+  }
 
-    const trimmedImage = configuredImage.trim();
+  const trimmedImage = configuredImage.trim();
 
-    if (trimmedImage.startsWith('/')) {
-        return trimmedImage;
-    }
+  if (trimmedImage.startsWith('/')) {
+    return trimmedImage;
+  }
 
-    if (/\.(png|svg|jpe?g|webp|gif)$/i.test(trimmedImage)) {
-        return `/assets/logos/${trimmedImage}`;
-    }
+  if (/\.(png|svg|jpe?g|webp|gif)$/i.test(trimmedImage)) {
+    return `/assets/logos/${trimmedImage}`;
+  }
 
-    return `/assets/logos/${normalizeLogoName(trimmedImage)}-logo.png`;
+  return `/assets/logos/${normalizeLogoName(trimmedImage)}-logo.png`;
 }
 
-export const SelectApp: React.FC<SelectAppProps> = ({ appDefinitions, onSelectApp }: SelectAppProps) => (
-    <div className='App__grid'>
-        {appDefinitions &&
-            appDefinitions
-                .filter(app => app.visible !== false)
-                .map((app, index) => (
-                    <button
-                        key={index}
-                        className='App__grid-item'
-                        onClick={() => onSelectApp(app.serviceAuthToken || app.appId, app.appName)}
-                        data-testid={`launch-app-${app.serviceAuthToken || app.appId}`}
-                    >
-                        <img src={getAppLogoSrc(app)} alt={`${app.appName} logo`} className='App__grid-item-logo' />
-                        <div className='App__grid-item-launch'>Select</div>
-                        <div className='App__grid-item-text'>{app.appName}</div>
-                    </button>
-                ))}
-    </div>
+export const SelectApp: React.FC<SelectAppProps> = ({ appDefinitions, onSelectApp, appMode }: SelectAppProps) => (
+  <div className='App__grid'>
+    {appDefinitions &&
+      appDefinitions
+        .filter(app => app.visible !== false)
+        .map((app, index) => {
+          const disabled = appMode === AppMode.AI && !app.aiVariant;
+          const token = appMode === AppMode.AI && app.aiVariant ? app.aiVariant : app.serviceAuthToken || app.appId;
+          return (<button
+            key={index}
+            className={`App__grid-item${disabled ? ' App__grid-item--disabled' : ''}`}
+            onClick={() => onSelectApp(token, app.appName)}
+            disabled={disabled}
+            data-testid={`launch-app-${app.serviceAuthToken || app.appId}`}
+          >
+            <img src={getAppLogoSrc(app)} alt={`${app.appName} logo`} className='App__grid-item-logo' />
+            <div className='App__grid-item-launch'>Select</div>
+            <div className='App__grid-item-text'>{app.appName}</div>
+          </button>);
+        })}
+  </div>
 );
+

--- a/src/components/SelectApp.tsx
+++ b/src/components/SelectApp.tsx
@@ -4,55 +4,56 @@ import type { ExtendedAppDefinition } from '../common-extensions/types';
 import { AppMode } from '../common-extensions/types';
 
 interface SelectAppProps {
-  appDefinitions: ExtendedAppDefinition[] | undefined;
-  onSelectApp: (appId: string, appName: string) => void;
-  appMode: AppMode;
+    appDefinitions: ExtendedAppDefinition[] | undefined;
+    onSelectApp: (appId: string, appName: string) => void;
+    appMode: AppMode;
 }
 
 function normalizeLogoName(value: string): string {
-  return value.trim().toLowerCase().replace(/\s+/g, '-');
+    return value.trim().toLowerCase().replace(/\s+/g, '-');
 }
 
 function getAppLogoSrc(app: ExtendedAppDefinition): string {
-  const configuredImage = app.image ?? app.Image;
+    const configuredImage = app.image ?? app.Image;
 
-  if (!configuredImage || configuredImage.trim().length === 0) {
-    return `/assets/logos/${normalizeLogoName(app.appName)}-logo.png`;
-  }
+    if (!configuredImage || configuredImage.trim().length === 0) {
+        return `/assets/logos/${normalizeLogoName(app.appName)}-logo.png`;
+    }
 
-  const trimmedImage = configuredImage.trim();
+    const trimmedImage = configuredImage.trim();
 
-  if (trimmedImage.startsWith('/')) {
-    return trimmedImage;
-  }
+    if (trimmedImage.startsWith('/')) {
+        return trimmedImage;
+    }
 
-  if (/\.(png|svg|jpe?g|webp|gif)$/i.test(trimmedImage)) {
-    return `/assets/logos/${trimmedImage}`;
-  }
+    if (/\.(png|svg|jpe?g|webp|gif)$/i.test(trimmedImage)) {
+        return `/assets/logos/${trimmedImage}`;
+    }
 
-  return `/assets/logos/${normalizeLogoName(trimmedImage)}-logo.png`;
+    return `/assets/logos/${normalizeLogoName(trimmedImage)}-logo.png`;
 }
 
 export const SelectApp: React.FC<SelectAppProps> = ({ appDefinitions, onSelectApp, appMode }: SelectAppProps) => (
-  <div className='App__grid'>
-    {appDefinitions &&
-      appDefinitions
-        .filter(app => app.visible !== false)
-        .map((app, index) => {
-          const disabled = appMode === AppMode.AI && !app.aiVariant;
-          const token = appMode === AppMode.AI && app.aiVariant ? app.aiVariant : app.serviceAuthToken || app.appId;
-          return (<button
-            key={index}
-            className={`App__grid-item${disabled ? ' App__grid-item--disabled' : ''}`}
-            onClick={() => onSelectApp(token, app.appName)}
-            disabled={disabled}
-            data-testid={`launch-app-${app.serviceAuthToken || app.appId}`}
-          >
-            <img src={getAppLogoSrc(app)} alt={`${app.appName} logo`} className='App__grid-item-logo' />
-            <div className='App__grid-item-launch'>Select</div>
-            <div className='App__grid-item-text'>{app.appName}</div>
-          </button>);
-        })}
-  </div>
+    <div className='App__grid'>
+        {appDefinitions &&
+            appDefinitions
+                .filter(app => app.visible !== false)
+                .map((app, index) => {
+                    const disabled = appMode === AppMode.AI && !app.aiVariant;
+                    const token = appMode === AppMode.AI && app.aiVariant ? app.aiVariant : app.serviceAuthToken || app.appId;
+                    return (
+                        <button
+                            key={index}
+                            className={`App__grid-item${disabled ? ' App__grid-item--disabled' : ''}`}
+                            onClick={() => onSelectApp(token, app.appName)}
+                            disabled={disabled}
+                            data-testid={`launch-app-${app.serviceAuthToken || app.appId}`}
+                        >
+                            <img src={getAppLogoSrc(app)} alt={`${app.appName} logo`} className='App__grid-item-logo' />
+                            <div className='App__grid-item-launch'>Select</div>
+                            <div className='App__grid-item-text'>{app.appName}</div>
+                        </button>
+                    );
+                })}
+    </div>
 );
-


### PR DESCRIPTION
### Features
Adds image variant selection to the landing page. The current images are set in the standard category and the ai images will be set in the AI variant category.

When the AI variant is configured, the image will be greyed out in the AI selection.

<img width="855" height="690" alt="image" src="https://github.com/user-attachments/assets/ae9447c9-0f50-4e9f-b8ca-7284ac69ed1b" />
<img width="905" height="721" alt="image" src="https://github.com/user-attachments/assets/e51495ce-ccff-486a-9c56-7d7f859e6590" />

See related PRs:
- https://github.com/EduIDE/EduIDE-deployment/pull/103
- https://github.com/EduIDE/EduIDE/pull/141
- https://github.com/EduIDE/EduIDE-Helm/pull/20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI mode support allowing users to select between standard and AI app variants.
  * Introduced mode selector UI for switching between application modes.

* **Documentation**
  * Updated README to document `aiVariant` field for specifying AI variant app definitions and clarified `image` field behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->