### PR TITLE
docs: fix git query params and document auto-clone credential

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,10 @@ The landing page supports various URL query parameters to pre-configure the sess
 | `gitUri` | string | Git repository URL to clone |
 | `gitUser` | string | Git username for authentication |
 | `gitMail` | string | Git email for authentication |
-| `gitToken` | string | Git authentication token |
 | `artemisUrl` | string | Artemis service URL |
 | `artemisToken` | string | Artemis authentication token |
+
+**Auto-clone and private repositories:** On session start the repository is cloned from `gitUri` exactly as provided; no credential is added. For a private repository the credential must be embedded in `gitUri` itself, for example `https://<user>:<token>@host/org/repo.git`. A plain `gitUri` without embedded credentials only works for public repositories. Because `gitUri` may contain a token, treat the URL as sensitive.
 
 Example: `https://your-landing-page.com/?appDef=myapp&gitUri=https://github.com/user/repo.git`
 


### PR DESCRIPTION
## Summary
- Remove the `gitToken` row from the README query-parameter table. `src/App.tsx` never parses `gitToken`, so it was never functional.
- Document that auto-clone of a private repository requires the credential embedded in `gitUri` (e.g. `https://<user>:<token>@host/org/repo.git`), because the landing page passes `GIT_URI` verbatim and the session image (Scorpio) clones it as-is. A plain `gitUri` only works for public repos.

## Why
The README advertised a parameter that does nothing and did not explain how the clone credential actually reaches the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iEasFrsCzFTCkRh5SP1KY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated query-parameter guidance to clarify repository cloning behavior.
  * Removed the `gitToken` parameter documentation.
  * Documented credential requirements for private repositories and warned that token-containing URLs are sensitive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->